### PR TITLE
Update Sample App to Use AndroidX

### DIFF
--- a/samples/FCMTutorialApp/app/build.gradle
+++ b/samples/FCMTutorialApp/app/build.gradle
@@ -8,7 +8,7 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -20,13 +20,13 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support:support-media-compat:28.0.0'
-    implementation 'com.android.support:support-v4:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.media:media:1.0.0'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test:runner:1.1.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
     implementation 'com.google.firebase:firebase-core:16.0.7'
     implementation 'com.google.android.gms:play-services-gcm:16.1.0'
     implementation 'com.microsoft.azure:notification-hubs-android-sdk:0.6@aar'

--- a/samples/FCMTutorialApp/app/src/main/java/com/microsoft/notificationhubs/fcmtutorialapp/MainActivity.java
+++ b/samples/FCMTutorialApp/app/src/main/java/com/microsoft/notificationhubs/fcmtutorialapp/MainActivity.java
@@ -1,6 +1,6 @@
 package com.microsoft.notificationhubs.fcmtutorialapp;
 
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;

--- a/samples/FCMTutorialApp/app/src/main/java/com/microsoft/notificationhubs/fcmtutorialapp/MyHandler.java
+++ b/samples/FCMTutorialApp/app/src/main/java/com/microsoft/notificationhubs/fcmtutorialapp/MyHandler.java
@@ -9,7 +9,7 @@ import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.v4.app.NotificationCompat;
+import androidx.core.app.NotificationCompat;
 import com.microsoft.windowsazure.notifications.NotificationsHandler;
 import com.microsoft.windowsazure.notifications.NotificationsManager;
 

--- a/samples/FCMTutorialApp/app/src/main/res/layout/activity_main.xml
+++ b/samples/FCMTutorialApp/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -16,4 +16,4 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/samples/FCMTutorialApp/build.gradle
+++ b/samples/FCMTutorialApp/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         classpath 'com.google.gms:google-services:4.2.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/samples/FCMTutorialApp/gradle.properties
+++ b/samples/FCMTutorialApp/gradle.properties
@@ -6,6 +6,8 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
Running through the tutorial [here](https://docs.microsoft.com/en-us/azure/notification-hubs/notification-hubs-android-push-notification-google-fcm-get-started), Android Studio 3.4.2 forced me to deviate from the instructions and use androidx.

These changes represent only changes that were generated by the `Refactor -> Migrate to AndroidX...` option in Android Studio, and an upgrade to gradle that it recommended.