### PR TITLE
Move removing local regID out from finally block

### DIFF
--- a/src/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/NotificationHub.java
+++ b/src/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/NotificationHub.java
@@ -477,12 +477,9 @@ public class NotificationHub {
 	private void deleteRegistrationInternal(String registrationName, String registrationId) throws Exception {
 		Connection conn = new Connection(mConnectionString);
 		String resource = mNotificationHubPath + "/Registrations/" + registrationId;
-		
-		try {
-			conn.executeRequest(resource, null, XML_CONTENT_TYPE, "DELETE", new SimpleEntry<String, String>("If-Match", "*"));
-		} finally {
-			removeRegistrationId(registrationName);
-		}
+
+		conn.executeRequest(resource, null, XML_CONTENT_TYPE, "DELETE", new SimpleEntry<String, String>("If-Match", "*"));
+		removeRegistrationId(registrationName);
 	}
 		
 	/**


### PR DESCRIPTION
Related issue: #34 
There are unexpected behavior of removing regID: we remove regID from device in spite of status of removing from notification hub.
In that case we can't to remove regID from notification hub because we doesn't have it on device. 
Then device continue receiving template notifications without possibility to remove this template. 