### PR TITLE
Updating version number for Decemeber release.

### DIFF
--- a/src/notification-hubs-sdk/build.gradle
+++ b/src/notification-hubs-sdk/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-def version = 0.6
+def version = '0.7.0'
 def PUBLISH_ARTIFACT_ID = 'notification-hubs-android-sdk'
 def groupId = 'com.microsoft.azure'
 


### PR DESCRIPTION
This operation required changing the type of `version` from number to string, in order to accommodate the multiple radix points in a semver.