### PR TITLE
Unpin test-app version of SDK, use project version instead.

### DIFF
--- a/notification-hubs-test-app/build.gradle
+++ b/notification-hubs-test-app/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
     implementation 'com.google.android.gms:play-services-gcm:16.0.0'
-    implementation 'com.microsoft.azure:notification-hubs-android-sdk:0.6@aar'
+    implementation project(":notification-hubs-sdk")
     implementation 'com.microsoft.azure:azure-notifications-handler:3.5.1@aar'
 }
 


### PR DESCRIPTION
e2e-app already used this model. The difference is just whether or not local developer changes automatically get pulled into the test-app when you're running it. I haven't been able to find any references to the test-app in tutorials, etc that may indicate that this isn't a good fit.