### PR TITLE
Save InstallationId in SharedPreferences.

### DIFF
--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/IdAssignmentVisitor.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/IdAssignmentVisitor.java
@@ -1,37 +1,53 @@
 package com.microsoft.windowsazure.messaging.notificationhubs;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+import com.microsoft.windowsazure.messaging.R;
 import java.util.UUID;
 
 class IdAssignmentVisitor implements InstallationVisitor {
+    private static final String PREFERENCE_KEY = "installationId";
+    private final SharedPreferences mPreferences;
 
-    private String mInstallationId;
-
-    public IdAssignmentVisitor() {
-        this(UUID.randomUUID().toString());
-    }
-
-    public IdAssignmentVisitor(String id) {
-        mInstallationId = id;
+    public IdAssignmentVisitor(Context context) {
+        mPreferences = context.getSharedPreferences(context.getString(R.string.installation_enrichment_file_key), Context.MODE_PRIVATE);
     }
 
     /**
-     * Modifies an {@link Installation} to add more information before being registered with a
-     * backend.
+     * Ensures that an {@link Installation} has a unique identifier associated with it before it is
+     * sent to the server.
      *
-     * @param subject The {@link Installation} that should be modified to include more detail.
+     * In no unique id has been set by the time this enrichment has been called, a UUID will be
+     * generated and used as the unique identifier. That UUID is preserved between calls to this
+     * method.
+     *
+     * @param subject The {@link Installation} to be updated to include an InstallationId.
      */
     @Override
     public void visitInstallation(Installation subject) {
         if(subject.getInstallationId() == null) {
-            subject.setInstallationId(mInstallationId);
+            String id = this.getInstallationId();
+            if (id == null) {
+                id = UUID.randomUUID().toString();
+                this.setInstallationId(id);
+            }
+            subject.setInstallationId(id);
         }
     }
 
+    /**
+     * Fetches the unique id that should be applied to installations from this device.
+     * @return The unique id to associate with this device, null if it has not been set.
+     */
     public String getInstallationId() {
-        return mInstallationId;
+        return mPreferences.getString(PREFERENCE_KEY, null);
     }
 
-    public void setInstallationId(String mInstallationId) {
-        this.mInstallationId = mInstallationId;
+    /**
+     * Updates the UUID that will be associated with future calls to `enrichInstallation`.
+     * @param installationId The unique identifier to apply.
+     */
+    public void setInstallationId(String installationId) {
+        mPreferences.edit().putString(PREFERENCE_KEY, installationId).apply();
     }
 }

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -28,8 +28,6 @@ public final class NotificationHub {
 
     NotificationHub() {
         mVisitors = new ArrayList<>();
-
-        mIdAssignmentVisitor = new IdAssignmentVisitor();
     }
 
     /**
@@ -44,18 +42,38 @@ public final class NotificationHub {
         return sInstance;
     }
 
+    /**
+     * Initialize the single global instance of {@link NotificationHub} and configure to associate
+     * this device with an Azure Notification Hub.
+     * @param context The application that will own the lifecycle and resources that NotificationHub
+     *                needs access to.
+     * @param hubName The name of the Notification Hub that will broadcast notifications to this
+     *                device.
+     * @param connectionString The Listen-only AccessPolicy that grants this device the ability to
+     *                         receive notifications.
+     */
     public static void initialize(Context context, String hubName, String connectionString) {
         initialize(context, new DebounceInstallationManager(new NotificationHubInstallationManager(
                 hubName,
                 connectionString)));
     }
 
+    /**
+     * Initialize the single global instance of {@link NotificationHub} and configure to associate
+     * this device with a custom backend that will store device references for future broadcasts.
+     *
+     * This is useful when your backend will exclusively use Notification Hub's direct send
+     * functionality.
+     * @param context The application that will own the lifecycle and resources that NotificationHub
+     *                needs access to.
+     * @param manager A client that can create/overwrite a reference to this device with a backend.
+     */
     public static void initialize(Context context, InstallationManager manager) {
         NotificationHub instance = getInstance();
         instance.setInstanceInstallationManager(manager);
         instance.mContext = context.getApplicationContext();
 
-        instance.mIdAssignmentVisitor = new IdAssignmentVisitor();
+        instance.mIdAssignmentVisitor = new IdAssignmentVisitor(instance.mContext);
         instance.useInstanceVisitor(instance.mIdAssignmentVisitor);
 
         instance.mTagVisitor = new TagVisitor(instance.mContext);

--- a/notification-hubs-test-app-refresh/src/main/java/com/example/notification_hubs_test_app_refresh/ui/main/SetupViewModel.java
+++ b/notification-hubs-test-app-refresh/src/main/java/com/example/notification_hubs_test_app_refresh/ui/main/SetupViewModel.java
@@ -20,17 +20,6 @@ public class SetupViewModel extends ViewModel {
     private final MutableLiveData<List<String>> mTags = new MutableLiveData<List<String>>();
 
     public SetupViewModel() {
-        NotificationHub.useVisitor(
-            // TODO: Instead of having this be InstallationMiddleware, which will get a partially
-            //       hydrated Installation, have this be an InstallationManager that intercepts the
-            //       call with the finalized installation.
-            subject -> {
-                String installationId = subject.getInstallationId();
-                if (installationId == null) {
-                    installationId = getUnknownText();
-                }
-                mInstallationId.setValue(installationId);
-            });
         mTags.setValue(iterableToList(NotificationHub.getTags()));
 
         String pushChannel = NotificationHub.getPushChannel();
@@ -38,14 +27,10 @@ public class SetupViewModel extends ViewModel {
             mDeviceToken.setValue(pushChannel);
         }
 
-        // TODO: This reinstall is forced to take advantage of the hook we setup above into the
-        //       Installation creation process. Honestly, this stinks. We shouldn't encourage people
-        //       to reinstall the app every time this screen is launched.
-        //       Because this is a sample application, we probably need to either decide to remove
-        //       the device token/installation id fields on the setup fragment, or add getters for
-        //       this information. This decisions will hinge on how common of scenario it is to
-        //       fetch your installation id or device token.
-        NotificationHub.reinstall();
+        String installationId = NotificationHub.getInstallationId();
+        if (installationId != null) {
+            mInstallationId.setValue(installationId);
+        }
     }
 
     public LiveData<String> getDeviceToken() {


### PR DESCRIPTION
Doing this reduces the frequency that the device will ask to be re-identified.