### PR TITLE
Move pushChannel storage out of the receiver.

### DIFF
--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
@@ -1,36 +1,21 @@
 package com.microsoft.windowsazure.messaging.notificationhubs;
 
-import android.content.Context;
-import android.content.Intent;
-import android.content.SharedPreferences;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
 
-import com.google.android.gms.tasks.OnCompleteListener;
-import com.google.android.gms.tasks.Task;
 import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.InstanceIdResult;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
-import com.microsoft.windowsazure.messaging.R;
 
 public final class FirebaseReceiver extends FirebaseMessagingService {
-
-    private static final String DEVICE_TOKEN_KEY = "DeviceToken";
-
-    private SharedPreferences mFirebasePreferences;
 
     @Override
     public void onCreate() {
         super.onCreate();
 
-        final String preferencesFile = getString(R.string.firebase_preference_file_key);
-        mFirebasePreferences = this.getSharedPreferences(
-                preferencesFile,
-                Context.MODE_PRIVATE);
 
-        if (!mFirebasePreferences.contains(DEVICE_TOKEN_KEY)) {
+        if (NotificationHub.getPushChannel() == null) {
             FirebaseInstanceId.getInstance()
                     .getInstanceId()
                     .addOnCompleteListener(task -> {
@@ -38,7 +23,7 @@ public final class FirebaseReceiver extends FirebaseMessagingService {
                             Log.e("ANH", "unable to fetch FirebaseInstanceId");
                             return;
                         }
-                        FirebaseReceiver.this.setDeviceToken(task.getResult().getToken());
+                        NotificationHub.setPushChannel(task.getResult().getToken());
                     });
         }
     }
@@ -50,7 +35,7 @@ public final class FirebaseReceiver extends FirebaseMessagingService {
 
     @Override
     public void onNewToken(@NonNull String s) {
-        setDeviceToken(s);
+        NotificationHub.setPushChannel(s);
     }
 
     /**
@@ -70,23 +55,5 @@ public final class FirebaseReceiver extends FirebaseMessagingService {
                 title,
                 body,
                 remoteMessage.getData());
-    }
-
-    public void setDeviceToken(String token){
-        NotificationHub.setPushChannel(token);
-        mFirebasePreferences.edit().putString(DEVICE_TOKEN_KEY, token);
-    }
-
-    /**
-     * Fetches the current Push Channel.
-     * @return The current string that identifies this device as Push notification receiver. Null if
-     *         it hasn't been initialized yet.
-     */
-    public String getDeviceToken() {
-        String retval = NotificationHub.getPushChannel();
-        if (retval == null) {
-            retval = mFirebasePreferences.getString(DEVICE_TOKEN_KEY, null);
-        }
-        return retval;
     }
 }

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -19,7 +19,7 @@ public final class NotificationHub {
 
     private NotificationListener mListener;
     private final List<InstallationVisitor> mVisitors;
-    private final PushChannelVisitor mPushChannelEnricher;
+    private PushChannelVisitor mPushChannelVisitor;
     private TagVisitor mTagVisitor;
     private IdAssignmentVisitor mIdAssignmentVisitor;
 
@@ -29,10 +29,7 @@ public final class NotificationHub {
     NotificationHub() {
         mVisitors = new ArrayList<>();
 
-        mPushChannelEnricher = new PushChannelVisitor();
         mIdAssignmentVisitor = new IdAssignmentVisitor();
-
-        FirebaseInstanceId.getInstance().getInstanceId().addOnCompleteListener(task -> this.setInstancePushChannel(task.getResult().getToken()));
     }
 
     /**
@@ -64,7 +61,13 @@ public final class NotificationHub {
         instance.mTagVisitor = new TagVisitor(instance.mContext);
         instance.useInstanceVisitor(instance.mTagVisitor);
 
-        instance.useInstanceVisitor(instance.mPushChannelEnricher);
+        instance.mPushChannelVisitor = new PushChannelVisitor(instance.mContext);
+        instance.useInstanceVisitor(instance.mPushChannelVisitor);
+
+        instance.useInstanceVisitor(instance.mPushChannelVisitor);
+
+        Intent i =  new Intent(context, FirebaseReceiver.class);
+        context.startService(i);
     }
 
     /**
@@ -165,7 +168,7 @@ public final class NotificationHub {
     }
 
     void setInstancePushChannel(String token) {
-        mPushChannelEnricher.setPushChannel(token);
+        mPushChannelVisitor.setPushChannel(token);
         reinstallInstance();
     }
 
@@ -175,7 +178,7 @@ public final class NotificationHub {
      *         it hasn't been initialized yet.
      */
     public String getInstancePushChannel() {
-        return mPushChannelEnricher.getPushChannel();
+        return mPushChannelVisitor.getPushChannel();
     }
 
     /**

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/PushChannelVisitor.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/PushChannelVisitor.java
@@ -1,14 +1,18 @@
 package com.microsoft.windowsazure.messaging.notificationhubs;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.core.graphics.drawable.IconCompat;
+
+import com.microsoft.windowsazure.messaging.R;
+
 public class PushChannelVisitor implements InstallationVisitor {
-    private String mChannel;
+    private static final String PREFERENCE_KEY = "pushChannel";
+    private final SharedPreferences mPreferences;
 
-    public PushChannelVisitor() {
-        // Intentionally Left Blank
-    }
-
-    public PushChannelVisitor(String pushChannel) {
-        mChannel = pushChannel;
+    public PushChannelVisitor(Context context) {
+        mPreferences = context.getSharedPreferences(context.getString(R.string.installation_enrichment_file_key), Context.MODE_PRIVATE);
     }
 
     /**
@@ -18,7 +22,7 @@ public class PushChannelVisitor implements InstallationVisitor {
      */
     @Override
     public void visitInstallation(Installation subject) {
-        subject.setPushChannel(mChannel);
+        subject.setPushChannel(getPushChannel());
     }
 
     /**
@@ -26,7 +30,7 @@ public class PushChannelVisitor implements InstallationVisitor {
      * @param channel The new unique identifier to apply.
      */
     public void setPushChannel(String channel) {
-        this.mChannel = channel;
+        mPreferences.edit().putString(PREFERENCE_KEY, channel).apply();
     }
 
     /**
@@ -35,6 +39,6 @@ public class PushChannelVisitor implements InstallationVisitor {
      *         it hasn't been initialized yet.
      */
     public String getPushChannel() {
-        return this.mChannel;
+        return mPreferences.getString(PREFERENCE_KEY, null);
     }
 }

--- a/notification-hubs-test-app-refresh/src/main/java/com/example/notification_hubs_test_app_refresh/ui/main/SetupViewModel.java
+++ b/notification-hubs-test-app-refresh/src/main/java/com/example/notification_hubs_test_app_refresh/ui/main/SetupViewModel.java
@@ -25,12 +25,6 @@ public class SetupViewModel extends ViewModel {
             //       hydrated Installation, have this be an InstallationManager that intercepts the
             //       call with the finalized installation.
             subject -> {
-                String pushChannel = subject.getPushChannel();
-                if (pushChannel == null) {
-                    pushChannel = getUnknownText();
-                }
-                mDeviceToken.setValue(pushChannel);
-
                 String installationId = subject.getInstallationId();
                 if (installationId == null) {
                     installationId = getUnknownText();
@@ -38,6 +32,11 @@ public class SetupViewModel extends ViewModel {
                 mInstallationId.setValue(installationId);
             });
         mTags.setValue(iterableToList(NotificationHub.getTags()));
+
+        String pushChannel = NotificationHub.getPushChannel();
+        if (pushChannel != null) {
+            mDeviceToken.setValue(pushChannel);
+        }
 
         // TODO: This reinstall is forced to take advantage of the hook we setup above into the
         //       Installation creation process. Honestly, this stinks. We shouldn't encourage people


### PR DESCRIPTION
This offers two advantages:
- `NotificationHub.getPushChannel` will be more available, not needing
to wait for FirebaseReceiver to get initialized before being able to
return results.
- This implementation is reusable across receiver implementations. This
allows FirebaseReceiver to be an even thinner wrapper.