### PR TITLE
Have NotificationHub take an Application instead of a Context.

### DIFF
--- a/notification-hubs-test-app-refresh/src/main/java/com/example/notification_hubs_test_app_refresh/MainActivity.java
+++ b/notification-hubs-test-app-refresh/src/main/java/com/example/notification_hubs_test_app_refresh/MainActivity.java
@@ -20,7 +20,7 @@ public class MainActivity extends AppCompatActivity {
         TabLayout tabs = findViewById(R.id.tabs);
         tabs.setupWithViewPager(viewPager);
 
-        NotificationHub.initialize(this.getApplicationContext(), BuildConfig.hubName, BuildConfig.hubListenConnectionString);
+        NotificationHub.initialize(this.getApplication(), BuildConfig.hubName, BuildConfig.hubListenConnectionString);
         NotificationHub.addTag("userAgent:com.example.notification_hubs_test_app_refresh:0.1.0");
     }
 }


### PR DESCRIPTION
`Application` is a type of `Context`, and the only type safe to capture in a static single instance. Other types like `Activity` or `Service` have life cycles that can be fairly temporary, and as such storing a reference to them is an anti pattern and can cause links. Prior to this PR, we ensured that we didn't capture a link to this using a pattern found in Volley's documentation, where one uses `getApplicationContext` on the `Context` handed to you in order to ensure we didn't create a leak. However, this is a departure from AppCenter's behavior of taking an `Application`, and will be an additional piece of migration work for our customers moving from Push. Because we'd like to make the migration from AppCenter Push as seamless as possible, and use the type system to prove we don't have memory leaks, this is the more appropriate pattern.

We initially made this change as part of moving passing an application context to a `NotificationListener` instead of an `Activity`. At the time, it seemed like using concrete types of `Context` anywhere you didn't have to was undesirable. But this lacked a bit of understanding about why passing an `Activity` was problematic.
