### PR TITLE
Enable/Disable NotificationHubs

### DIFF
--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -29,6 +29,7 @@ public final class NotificationHub {
     private InstallationAdapter mManager;
     private Application mApplication;
     private Class mReceiver;
+    private boolean mIsEnabled = true;
 
     NotificationHub() {
         mVisitors = new ArrayList<>();
@@ -385,30 +386,34 @@ public final class NotificationHub {
         }
     }
 
-    void setInstanceReceiver(Class receiver) {
-        mReceiver = receiver;
+    /**
+     * Controls whether or not this application should be listening for Notifications.
+     * @param enable true if the application should be listening for notifications, false if not.
+     */
+    public static void setEnabled(boolean enable) {
+        getInstance().setInstanceEnabled(enable);
     }
 
     /**
      * Controls whether or not this application should be listening for Notifications.
      * @param enable true if the application should be listening for notifications, false if not.
      */
-    public static void setEnabled(Context context, boolean enable) {
-        getInstance().setInstanceEnabled(context, enable);
-    }
-
-    /**
-     * Controls whether or not this application should be listening for Notifications.
-     * @param enable true if the application should be listening for notifications, false if not.
-     */
-    public void setInstanceEnabled(Context context, boolean enable) {
-        Intent i = new Intent(context.getApplicationContext(), mReceiver);
-        context = context.getApplicationContext();
+    public void setInstanceEnabled(boolean enable) {
+        Intent i = new Intent(mContext, mReceiver);
 
         if (enable) {
-            context.startService(i);
+            mContext.startService(i);
         } else {
-            context.stopService(i);
+            mContext.stopService(i);
         }
+
+    }
+
+    public static boolean isEnabled() {
+        return getInstance().isInstanceEnabled();
+    }
+
+    public boolean isInstanceEnabled() {
+        return mIsEnabled;
     }
 }

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -418,6 +418,6 @@ public final class NotificationHub {
     }
 
     public boolean isInstanceEnabled() {
-        return mPreferences.getBoolean(IS_ENABLED_PREFERENCE_KEY, false);
+        return mPreferences.getBoolean(IS_ENABLED_PREFERENCE_KEY, true);
     }
 }

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -2,6 +2,7 @@ package com.microsoft.windowsazure.messaging.notificationhubs;
 
 import android.app.Activity;
 import android.app.Application;
+import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.ConnectivityManager;
@@ -27,6 +28,7 @@ public final class NotificationHub {
 
     private InstallationAdapter mManager;
     private Application mApplication;
+    private Class mReceiver;
 
     NotificationHub() {
         mVisitors = new ArrayList<>();
@@ -380,6 +382,33 @@ public final class NotificationHub {
         if (mTagVisitor.getTags().iterator().hasNext()) {
             mTagVisitor.clearTags();
             this.reinstallInstance();
+        }
+    }
+
+    void setInstanceReceiver(Class receiver) {
+        mReceiver = receiver;
+    }
+
+    /**
+     * Controls whether or not this application should be listening for Notifications.
+     * @param enable true if the application should be listening for notifications, false if not.
+     */
+    public static void setEnabled(Context context, boolean enable) {
+        getInstance().setInstanceEnabled(context, enable);
+    }
+
+    /**
+     * Controls whether or not this application should be listening for Notifications.
+     * @param enable true if the application should be listening for notifications, false if not.
+     */
+    public void setInstanceEnabled(Context context, boolean enable) {
+        Intent i = new Intent(context.getApplicationContext(), mReceiver);
+        context = context.getApplicationContext();
+
+        if (enable) {
+            context.startService(i);
+        } else {
+            context.stopService(i);
         }
     }
 }

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -410,7 +410,9 @@ public final class NotificationHub {
      */
     public void setInstanceEnabled(boolean enable) {
         mPreferences.edit().putBoolean(IS_ENABLED_PREFERENCE_KEY, enable).apply();
-
+        if (enable) {
+            reinstallInstance();
+        }
     }
 
     public static boolean isEnabled() {

--- a/notification-hubs-test-app-refresh/src/main/java/com/example/notification_hubs_test_app_refresh/ui/main/SetupFragment.java
+++ b/notification-hubs-test-app-refresh/src/main/java/com/example/notification_hubs_test_app_refresh/ui/main/SetupFragment.java
@@ -51,8 +51,7 @@ public class SetupFragment extends Fragment {
         mViewModel.getInstallationId().observe(getViewLifecycleOwner(), installationIdValue::setText);
 
         final Switch isEnabled = root.findViewById(R.id.enabled_switch);
-        mViewModel.getIsEnabled().observe(getViewLifecycleOwner(), b -> {
-        });
+        mViewModel.getIsEnabled().observe(getViewLifecycleOwner(), isEnabled::setChecked);
         isEnabled.setOnCheckedChangeListener((buttonView, isChecked) -> mViewModel.setIsEnabled(isChecked));
 
         final EditText tagToAddField = root.findViewById(R.id.add_tag_field);

--- a/notification-hubs-test-app-refresh/src/main/java/com/example/notification_hubs_test_app_refresh/ui/main/SetupFragment.java
+++ b/notification-hubs-test-app-refresh/src/main/java/com/example/notification_hubs_test_app_refresh/ui/main/SetupFragment.java
@@ -11,15 +11,19 @@ import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.CompoundButton;
 import android.widget.EditText;
+import android.widget.Switch;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import com.example.notification_hubs_test_app_refresh.R;
+import com.microsoft.windowsazure.messaging.notificationhubs.NotificationHub;
 
 import java.util.List;
 
@@ -41,12 +45,15 @@ public class SetupFragment extends Fragment {
         View root = inflater.inflate(R.layout.setup_fragment, container, false);
 
         final TextView deviceTokenValue = root.findViewById(R.id.device_token_value);
-        final Observer<String> deviceTokenObserver = s -> deviceTokenValue.setText(s);
-        mViewModel.getDeviceToken().observe(getViewLifecycleOwner(), deviceTokenObserver);
+        mViewModel.getDeviceToken().observe(getViewLifecycleOwner(), deviceTokenValue::setText);
 
         final TextView installationIdValue = root.findViewById(R.id.installation_id_value);
-        final Observer<String> installationIdObserver = s -> installationIdValue.setText(s);
-        mViewModel.getInstallationId().observe(getViewLifecycleOwner(), installationIdObserver);
+        mViewModel.getInstallationId().observe(getViewLifecycleOwner(), installationIdValue::setText);
+
+        final Switch isEnabled = root.findViewById(R.id.enabled_switch);
+        mViewModel.getIsEnabled().observe(getViewLifecycleOwner(), b -> {
+        });
+        isEnabled.setOnCheckedChangeListener((buttonView, isChecked) -> mViewModel.setIsEnabled(isChecked));
 
         final EditText tagToAddField = root.findViewById(R.id.add_tag_field);
         final Button tagToAddButton = root.findViewById(R.id.add_tag_button);

--- a/notification-hubs-test-app-refresh/src/main/java/com/example/notification_hubs_test_app_refresh/ui/main/SetupViewModel.java
+++ b/notification-hubs-test-app-refresh/src/main/java/com/example/notification_hubs_test_app_refresh/ui/main/SetupViewModel.java
@@ -19,8 +19,11 @@ public class SetupViewModel extends ViewModel {
     private final MutableLiveData<String> mInstallationId = new MutableLiveData<String>();
     private final MutableLiveData<List<String>> mTags = new MutableLiveData<List<String>>();
 
+    private final MutableLiveData<Boolean> mIsEnabled = new MutableLiveData<Boolean>();
+
     public SetupViewModel() {
         mTags.setValue(iterableToList(NotificationHub.getTags()));
+        mIsEnabled.setValue(NotificationHub.isEnabled());
 
         String pushChannel = NotificationHub.getPushChannel();
         if (pushChannel != null) {
@@ -48,6 +51,15 @@ public class SetupViewModel extends ViewModel {
     public void setInstallationId(String installationId) {
         NotificationHub.setInstallationId(installationId);
         mInstallationId.setValue(installationId);
+    }
+
+    public LiveData<Boolean> getIsEnabled() {
+        return mIsEnabled;
+    }
+
+    public void setIsEnabled(boolean b) {
+        NotificationHub.setEnabled(b);
+        mIsEnabled.setValue(NotificationHub.isEnabled());
     }
 
     public LiveData<List<String>> getTags() {

--- a/notification-hubs-test-app-refresh/src/main/res/layout/setup_fragment.xml
+++ b/notification-hubs-test-app-refresh/src/main/res/layout/setup_fragment.xml
@@ -67,7 +67,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/installation_id_value" />
+        app:layout_constraintTop_toBottomOf="@+id/enabled_switch" />
 
     <TextView
         android:id="@+id/device_token_label"
@@ -107,5 +107,18 @@
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/add_tag_field" />
+
+    <Switch
+        android:id="@+id/enabled_switch"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:text="@string/enabled_label"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/installation_id_value" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/notification-hubs-test-app-refresh/src/main/res/layout/setup_fragment.xml
+++ b/notification-hubs-test-app-refresh/src/main/res/layout/setup_fragment.xml
@@ -117,6 +117,7 @@
         android:layout_marginEnd="16dp"
         android:text="@string/enabled_label"
         android:textStyle="bold"
+        android:textColor="@android:color/tab_indicator_text"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/installation_id_value" />

--- a/notification-hubs-test-app-refresh/src/main/res/values/strings.xml
+++ b/notification-hubs-test-app-refresh/src/main/res/values/strings.xml
@@ -13,4 +13,5 @@
     <string name="notification_data_label">Data:</string>
     <string name="notification_data_cardinality_label">Data Field Count:</string>
     <string name="notification_received_message">Notification Received</string>
+    <string name="enabled_label">Enabled:</string>
 </resources>


### PR DESCRIPTION
App Center gave the ability to enable/disable support for its different modules, like Push, Analytics, etc. Notably, [as mentioned in their Android docs](https://docs.microsoft.com/en-us/appcenter/sdk/push/android#enable-or-disable-app-center-push-at-runtime), their implementation doesn't actually stop the device from receiving notifications. It just App Center from being alerted to new changes to the installation.