### PR TITLE
Ensure POM contains <packaging>aar</packaging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:3.6.3'
         classpath 'com.google.gms:google-services:4.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/notification-hubs-sdk/build.gradle
+++ b/notification-hubs-sdk/build.gradle
@@ -66,6 +66,11 @@ task clearJar(type: Delete) {
     delete 'build/release/' + PUBLISH_ARTIFACT_ID + '-' + version + '.jar'
 }
 
+task writeVersionFile() {
+    File versionFileHandle = new File("$buildDir/repo/com/microsoft/azure/notification-hubs-android-sdk/version.txt")
+    versionFileHandle.write VERSION
+}
+
 // step 1
 task makeJar(type: Copy) {
     from('build/intermediates/aar_main_jar/release/')

--- a/notification-hubs-sdk/build.gradle
+++ b/notification-hubs-sdk/build.gradle
@@ -5,14 +5,6 @@ def VERSION = '1.0.0-preview1'
 def PUBLISH_ARTIFACT_ID = 'notification-hubs-android-sdk'
 def GROUP_ID = 'com.microsoft.azure'
 
-def BINTRAY_USERNAME = "$System.env.BINTRAY_USERNAME"
-def BINTRAY_APIKEY = "$System.env.BINTRAY_APIKEY"
-
-// def isCI = project.hasProperty('isCI') ? Boolean.valueOf(isCI) : false
-// def repoUrl = isCI ? "file://" + "$System.env.BUILD_ARTIFACTSTAGINGDIRECTORY" : 'https://api.bintray.com/maven/microsoftazuremobile/SDK/Notification-Hubs-Android-SDK'
-def repoUrl = "file://C:/code/github.com/Azure/azure-notificationhubs-android/notification-hubs-sdk/build/foo"
-// def repoUrl = 'https://api.bintray.com/maven/marstr/NH-experiments/nh-android-experiments'
-
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 

--- a/notification-hubs-sdk/build.gradle
+++ b/notification-hubs-sdk/build.gradle
@@ -66,9 +66,11 @@ task clearJar(type: Delete) {
     delete 'build/release/' + PUBLISH_ARTIFACT_ID + '-' + version + '.jar'
 }
 
-task writeVersionFile() {
-    File versionFileHandle = new File("$buildDir/repo/com/microsoft/azure/notification-hubs-android-sdk/version.txt")
-    versionFileHandle.write VERSION
+task writeVersionFile {
+    doLast {
+        File versionFileHandle = new File("$buildDir/repo/com/microsoft/azure/notification-hubs-android-sdk/version.txt")
+        versionFileHandle.write VERSION
+    }
 }
 
 // step 1

--- a/notification-hubs-sdk/build.gradle
+++ b/notification-hubs-sdk/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
-def version = '1.0.0-preview1'
+def VERSION = '1.0.0-preview1'
 def PUBLISH_ARTIFACT_ID = 'notification-hubs-android-sdk'
-def groupId = 'com.microsoft.azure'
+def GROUP_ID = 'com.microsoft.azure'
 
 def BINTRAY_USERNAME = "$System.env.BINTRAY_USERNAME"
 def BINTRAY_APIKEY = "$System.env.BINTRAY_APIKEY"
@@ -20,7 +20,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName version
+        versionName VERSION
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         testInstrumentationRunnerArguments clearPackageData: 'true'
     }
@@ -84,30 +84,25 @@ task makeJar(type: Copy) {
 
 makeJar.dependsOn(clearJar, build)
 
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                groupId = GROUP_ID
+                artifactId = PUBLISH_ARTIFACT_ID
+                version = VERSION
 
-// step 2
-uploadArchives {
-    repositories.mavenDeployer {
-        pom.groupId = groupId
-        pom.artifactId = PUBLISH_ARTIFACT_ID
-        pom.version = version
-        pom.project {
-            packaging 'aar'
-            name 'Notification Hub'
-            description 'NotificationHub Android SDK'
-            url 'https://github.com/Azure/azure-notificationhubs'
+                from components.release
+            }
         }
-        repository (
-            url: repoUrl
-        ) {
-            authentication(
-                userName: BINTRAY_USERNAME,
-                password: BINTRAY_APIKEY
-            )
+        repositories {
+            maven {
+                name = 'MarStr'
+                url = 'file://C:/foo/'
+            }
         }
     }
 }
-
 
 task androidJavadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs

--- a/notification-hubs-sdk/build.gradle
+++ b/notification-hubs-sdk/build.gradle
@@ -72,7 +72,6 @@ task writeVersionFile {
         versionFileHandle.write VERSION
     }
 }
-writeVersionFile.dependsOn(publishReleasePublicationToBuildDirRepository)
 
 // step 1
 task makeJar(type: Copy) {

--- a/notification-hubs-sdk/build.gradle
+++ b/notification-hubs-sdk/build.gradle
@@ -8,8 +8,10 @@ def groupId = 'com.microsoft.azure'
 def BINTRAY_USERNAME = "$System.env.BINTRAY_USERNAME"
 def BINTRAY_APIKEY = "$System.env.BINTRAY_APIKEY"
 
-def isCI = project.hasProperty('isCI') ? Boolean.valueOf(isCI) : false
-def repoUrl = isCI ? "file://" + "$System.env.BUILD_ARTIFACTSTAGINGDIRECTORY" : 'https://api.bintray.com/maven/microsoftazuremobile/SDK/Notification-Hubs-Android-SDK'
+// def isCI = project.hasProperty('isCI') ? Boolean.valueOf(isCI) : false
+// def repoUrl = isCI ? "file://" + "$System.env.BUILD_ARTIFACTSTAGINGDIRECTORY" : 'https://api.bintray.com/maven/microsoftazuremobile/SDK/Notification-Hubs-Android-SDK'
+def repoUrl = "file://C:/code/github.com/Azure/azure-notificationhubs-android/notification-hubs-sdk/build/foo"
+// def repoUrl = 'https://api.bintray.com/maven/marstr/NH-experiments/nh-android-experiments'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion

--- a/notification-hubs-sdk/build.gradle
+++ b/notification-hubs-sdk/build.gradle
@@ -72,6 +72,7 @@ task writeVersionFile {
         versionFileHandle.write VERSION
     }
 }
+writeVersionFile.dependsOn(publishReleasePublicationToBuildDirRepository)
 
 // step 1
 task makeJar(type: Copy) {

--- a/notification-hubs-sdk/build.gradle
+++ b/notification-hubs-sdk/build.gradle
@@ -97,8 +97,8 @@ afterEvaluate {
         }
         repositories {
             maven {
-                name = 'MarStr'
-                url = 'file://C:/foo/'
+                name = 'BuildDir'
+                url = "file://$buildDir/repo"
             }
         }
     }


### PR DESCRIPTION
This swaps out the gradle plugin that is used to build our distributable for a more modern one. (Also, it's the one Google uses for [their projects](https://github.com/google/volley/blob/c9b2623cb524d2ec29a5a7f012528115f45b24cd/bintray.gradle#L16).)