### PR TITLE
Expose installation extension points

### DIFF
--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/DebounceInstallationAdapter.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/DebounceInstallationAdapter.java
@@ -9,7 +9,11 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-class DebounceInstallationAdapter implements InstallationAdapter {
+/**
+ * Protects the {@link InstallationAdapter} from rapid changes to the current Installation, as well
+ * as weeding out calls that match the last request that was sent to the server.
+ */
+public class DebounceInstallationAdapter implements InstallationAdapter {
 
     private static final String PREFERENCE_KEY = "recentInstallation";
     private final ScheduledExecutorService mScheduler = Executors.newScheduledThreadPool(1);

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/InstallationAdapter.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/InstallationAdapter.java
@@ -2,7 +2,14 @@ package com.microsoft.windowsazure.messaging.notificationhubs;
 
 import android.content.Context;
 
-interface InstallationAdapter {
+/**
+ * Defines the operations that must implemented in order to communicate with a backend that is
+ * keeps track of registered devices.
+ *
+ * The default implementation of this interface is the {@link NotificationHubInstallationAdapter},
+ * which will keep the Notification Hubs backend up-to-date.
+ */
+public interface InstallationAdapter {
     /**
      * Updates a backend with the updated Installation information for this device.
      * @param context Application context.

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/InstallationVisitor.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/InstallationVisitor.java
@@ -3,7 +3,7 @@ package com.microsoft.windowsazure.messaging.notificationhubs;
 /**
  * A contract for allowing updates to an {@link Installation}.
  */
-interface InstallationVisitor {
+public interface InstallationVisitor {
     /**
      * Modifies an {@link Installation} to add more information before being registered with a
      * backend.

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -78,7 +78,7 @@ public final class NotificationHub {
      */
     public static void initialize(Application application, InstallationAdapter adapter) {
         NotificationHub instance = getInstance();
-        instance.setInstanceInstallationAdapter(adapter);
+        instance.mManager = adapter;
         instance.mApplication = application;
 
         instance.mPreferences = instance.mApplication.getSharedPreferences(INSTALLATION_PREFERENCE_LOCATION, Context.MODE_PRIVATE);
@@ -158,22 +158,6 @@ public final class NotificationHub {
      */
     void useInstanceVisitor(InstallationVisitor visitor) {
         mVisitors.add(visitor);
-    }
-
-    /**
-     * Updates the mechanism that will be used to inform a backend service of the new installation.
-     * @param adapter An instance of the {@link InstallationAdapter} that should be used.
-     */
-    static void setInstallationAdapter(InstallationAdapter adapter) {
-        getInstance().setInstanceInstallationAdapter(adapter);
-    }
-
-    /**
-     * Updates the mechanism that will be used to inform a backend service of the new installation.
-     * @param adapter An instance of the {@link InstallationAdapter} that should be used.
-     */
-    void setInstanceInstallationAdapter(InstallationAdapter adapter) {
-        mManager = adapter;
     }
 
     /**

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -143,7 +143,7 @@ public final class NotificationHub {
      * @param visitor A {@link InstallationVisitor} to invoke when creating a new
      *                   {@link Installation}.
      */
-    static void useVisitor(InstallationVisitor visitor) {
+    public static void useVisitor(InstallationVisitor visitor) {
         getInstance().useInstanceVisitor(visitor);
     }
 
@@ -156,7 +156,7 @@ public final class NotificationHub {
      * @param visitor A {@link InstallationVisitor} to invoke when creating a new
      *                   {@link Installation}.
      */
-    void useInstanceVisitor(InstallationVisitor visitor) {
+    public void useInstanceVisitor(InstallationVisitor visitor) {
         mVisitors.add(visitor);
     }
 

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -76,7 +76,7 @@ public final class NotificationHub {
      *                needs access to.
      * @param adapter A client that can create/overwrite a reference to this device with a backend.
      */
-    static void initialize(Application application, InstallationAdapter adapter) {
+    public static void initialize(Application application, InstallationAdapter adapter) {
         NotificationHub instance = getInstance();
         instance.setInstanceInstallationAdapter(adapter);
         instance.mApplication = application;

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -28,7 +28,7 @@ public final class NotificationHub {
     private TemplateVisitor mTemplateVisitor;
     private IdAssignmentVisitor mIdAssignmentVisitor;
 
-    private InstallationAdapter mManager;
+    private InstallationAdapter mAdapter;
     private Application mApplication;
 
     private SharedPreferences mPreferences;
@@ -78,7 +78,7 @@ public final class NotificationHub {
      */
     public static void initialize(Application application, InstallationAdapter adapter) {
         NotificationHub instance = getInstance();
-        instance.mManager = adapter;
+        instance.mAdapter = adapter;
         instance.mApplication = application;
 
         instance.mPreferences = instance.mApplication.getSharedPreferences(INSTALLATION_PREFERENCE_LOCATION, Context.MODE_PRIVATE);
@@ -180,8 +180,8 @@ public final class NotificationHub {
             visitor.visitInstallation(installation);
         }
 
-        if (mManager != null) {
-            mManager.saveInstallation(mApplication, installation);
+        if (mAdapter != null) {
+            mAdapter.saveInstallation(mApplication, installation);
         }
     }
 

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/PushChannelVisitor.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/PushChannelVisitor.java
@@ -3,7 +3,7 @@ package com.microsoft.windowsazure.messaging.notificationhubs;
 import android.content.Context;
 import android.content.SharedPreferences;
 
-public class PushChannelVisitor implements InstallationVisitor {
+class PushChannelVisitor implements InstallationVisitor {
     private static final String PREFERENCE_KEY = "pushChannel";
     private final SharedPreferences mPreferences;
 

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/TagVisitor.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/TagVisitor.java
@@ -12,7 +12,7 @@ import java.util.Set;
  * Collects a set of distinct tags, in order to apply them to {@link Installation}s as they are
  * created.
  */
-public class TagVisitor implements InstallationVisitor, Taggable {
+class TagVisitor implements InstallationVisitor, Taggable {
 
     private static final String PREFERENCE_KEY = "tags";
     private SharedPreferences mPreferences;

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/TemplateVisitor.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/TemplateVisitor.java
@@ -19,7 +19,7 @@ import java.util.Set;
  * Collects a set of distinct templates, in order to apply them to {@link Installation}s as they are
  * created.
  */
-public class TemplateVisitor implements InstallationVisitor {
+class TemplateVisitor implements InstallationVisitor {
 
     private static final String PREFERENCE_KEY = "templates";
     private SharedPreferences mPreferences;


### PR DESCRIPTION
These changes add a mechanism for customers to target different backends for keeping track of devices, as well as a way to further enrich `Installation`s before they are sent to the backend.