### PR TITLE
Reference shared prefs file consistently

### DIFF
--- a/notification-hubs-sdk/src/androidTest/java/com/microsoft/windowsazure/messaging/notificationhubs/DebouncerTest.java
+++ b/notification-hubs-sdk/src/androidTest/java/com/microsoft/windowsazure/messaging/notificationhubs/DebouncerTest.java
@@ -5,6 +5,8 @@ import android.content.SharedPreferences;
 
 import androidx.test.filters.SmallTest;
 
+import com.microsoft.windowsazure.messaging.R;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -137,7 +139,7 @@ public class DebouncerTest {
         Thread.sleep(debouncerDelayPlusSecond);
 
         String PREFERENCE_KEY = "recentInstallation";
-        SharedPreferences mPreferences = context.getSharedPreferences(NotificationHub.INSTALLATION_PREFERENCE_LOCATION, Context.MODE_MULTI_PROCESS);
+        SharedPreferences mPreferences = context.getSharedPreferences(context.getString(R.string.installation_enrichment_file_key), Context.MODE_MULTI_PROCESS);
         int recentHash = mPreferences.getInt(PREFERENCE_KEY,0);
 
         assertTrue(recentHash == installation.hashCode());

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/DebounceInstallationAdapter.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/DebounceInstallationAdapter.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
 
+import com.microsoft.windowsazure.messaging.R;
+
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -30,7 +32,7 @@ public class DebounceInstallationAdapter implements InstallationAdapter {
         super();
         mInstallationAdapter = installationAdapter;
         mInterval = interval;
-        mPreferences = context.getSharedPreferences(NotificationHub.INSTALLATION_PREFERENCE_LOCATION, Context.MODE_MULTI_PROCESS);
+        mPreferences = context.getSharedPreferences(context.getString(R.string.installation_enrichment_file_key), Context.MODE_MULTI_PROCESS);
     }
 
 

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/IdAssignmentVisitor.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/IdAssignmentVisitor.java
@@ -2,6 +2,7 @@ package com.microsoft.windowsazure.messaging.notificationhubs;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import com.microsoft.windowsazure.messaging.R;
 import java.util.UUID;
 
 /**
@@ -12,7 +13,7 @@ class IdAssignmentVisitor implements InstallationVisitor {
     private final SharedPreferences mPreferences;
 
     public IdAssignmentVisitor(Context context) {
-        mPreferences = context.getSharedPreferences(NotificationHub.INSTALLATION_PREFERENCE_LOCATION, Context.MODE_PRIVATE);
+        mPreferences = context.getSharedPreferences(context.getString(R.string.installation_enrichment_file_key), Context.MODE_PRIVATE);
     }
 
     /**

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -9,6 +9,8 @@ import android.content.SharedPreferences;
 import android.net.ConnectivityManager;
 import android.util.Log;
 
+import com.microsoft.windowsazure.messaging.R;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -18,8 +20,6 @@ import java.util.List;
  * Notification Hubs.
  */
 public final class NotificationHub {
-    static final String INSTALLATION_PREFERENCE_LOCATION = "com.microsoft.windowsazure.messaging.notificationhubs.InstallationSharedPreferences";
-
     private static NotificationHub sInstance;
 
     private NotificationListener mListener;
@@ -98,7 +98,7 @@ public final class NotificationHub {
         instance.mAdapter = adapter;
         instance.mApplication = application;
 
-        instance.mPreferences = instance.mApplication.getSharedPreferences(INSTALLATION_PREFERENCE_LOCATION, Context.MODE_PRIVATE);
+        instance.mPreferences = instance.mApplication.getSharedPreferences(instance.mApplication.getString(R.string.installation_enrichment_file_key), Context.MODE_PRIVATE);
 
         instance.mIdAssignmentVisitor = new IdAssignmentVisitor(instance.mApplication);
         instance.useInstanceVisitor(instance.mIdAssignmentVisitor);

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/PushChannelVisitor.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/PushChannelVisitor.java
@@ -3,12 +3,14 @@ package com.microsoft.windowsazure.messaging.notificationhubs;
 import android.content.Context;
 import android.content.SharedPreferences;
 
-class PushChannelVisitor implements InstallationVisitor {
+import com.microsoft.windowsazure.messaging.R;
+
+public class PushChannelVisitor implements InstallationVisitor {
     private static final String PREFERENCE_KEY = "pushChannel";
     private final SharedPreferences mPreferences;
 
     public PushChannelVisitor(Context context) {
-        mPreferences = context.getSharedPreferences(NotificationHub.INSTALLATION_PREFERENCE_LOCATION, Context.MODE_PRIVATE);
+        mPreferences = context.getSharedPreferences(context.getString(R.string.installation_enrichment_file_key), Context.MODE_PRIVATE);
     }
 
     /**

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/TagVisitor.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/TagVisitor.java
@@ -3,6 +3,8 @@ package com.microsoft.windowsazure.messaging.notificationhubs;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import com.microsoft.windowsazure.messaging.R;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -22,7 +24,7 @@ class TagVisitor implements InstallationVisitor, Taggable {
      * @param context Application context
      */
     public TagVisitor(Context context) {
-        mPreferences = context.getSharedPreferences(NotificationHub.INSTALLATION_PREFERENCE_LOCATION, Context.MODE_PRIVATE);
+        mPreferences = context.getSharedPreferences(context.getString(R.string.installation_enrichment_file_key), Context.MODE_PRIVATE);
     }
 
     private Set<String> getTagsSet() {


### PR DESCRIPTION
We had previously knee-jerk removed the SharedPreferences Installation file location constant out of `values/strings.xml` into hard-coded constants when we were having trouble with AAR/JAR distribution. Now that we have that sorted out, we can go back to using the strings.xml file which will be distributed in the AAR.