### PR TITLE
Remove Context from InstallationAdapter.saveInstallation signature

### DIFF
--- a/notification-hubs-sdk/src/androidTest/java/com/microsoft/windowsazure/messaging/notificationhubs/DebouncerTest.java
+++ b/notification-hubs-sdk/src/androidTest/java/com/microsoft/windowsazure/messaging/notificationhubs/DebouncerTest.java
@@ -65,77 +65,77 @@ public class DebouncerTest {
     public void DebouncerDoesNotInvokeSaveImmediately() {
         NotificationHubInstallationAdapter nhInstallationManager = mock(NotificationHubInstallationAdapter.class);
         DebounceInstallationAdapter debouncer = new DebounceInstallationAdapter(context, nhInstallationManager);
-        debouncer.saveInstallation(context, installation, logSuccessListener, logFailureListener);
-        verify(nhInstallationManager, times(0)).saveInstallation(context, installation, logSuccessListener, logFailureListener);
+        debouncer.saveInstallation(installation, logSuccessListener, logFailureListener);
+        verify(nhInstallationManager, times(0)).saveInstallation(installation, logSuccessListener, logFailureListener);
     }
 
     @Test
     public void DebouncerInvokesSaveAfterDelayHappyPath() throws InterruptedException {
         NotificationHubInstallationAdapter nhInstallationManager = mock(NotificationHubInstallationAdapter.class);
         DebounceInstallationAdapter debouncer = new DebounceInstallationAdapter(context, nhInstallationManager);
-        debouncer.saveInstallation(context, installation, logSuccessListener, logFailureListener);
+        debouncer.saveInstallation(installation, logSuccessListener, logFailureListener);
         Thread.sleep(debouncerDelayPlusSecond);
-        verify(nhInstallationManager, times(1)).saveInstallation(context, installation, logSuccessListener, logFailureListener);
+        verify(nhInstallationManager, times(1)).saveInstallation(installation, logSuccessListener, logFailureListener);
     }
 
     @Test
     public void DebouncerInvokesSaveForMostRecent() throws InterruptedException {
         NotificationHubInstallationAdapter nhInstallationManager = mock(NotificationHubInstallationAdapter.class);
         DebounceInstallationAdapter debouncer = new DebounceInstallationAdapter(context, nhInstallationManager);
-        debouncer.saveInstallation(context, installation, logSuccessListener, logFailureListener);
-        debouncer.saveInstallation(context, installation_second, logSuccessListener, logFailureListener);
-        debouncer.saveInstallation(context, installation_third, logSuccessListener, logFailureListener);
+        debouncer.saveInstallation(installation, logSuccessListener, logFailureListener);
+        debouncer.saveInstallation(installation_second, logSuccessListener, logFailureListener);
+        debouncer.saveInstallation(installation_third, logSuccessListener, logFailureListener);
         Thread.sleep(debouncerDelayPlusSecond);
-        verify(nhInstallationManager, times(0)).saveInstallation(context, installation, logSuccessListener, logFailureListener);
-        verify(nhInstallationManager, times(0)).saveInstallation(context, installation_second, logSuccessListener, logFailureListener);
-        verify(nhInstallationManager, times(1)).saveInstallation(context, installation_third, logSuccessListener, logFailureListener);
+        verify(nhInstallationManager, times(0)).saveInstallation(installation, logSuccessListener, logFailureListener);
+        verify(nhInstallationManager, times(0)).saveInstallation(installation_second, logSuccessListener, logFailureListener);
+        verify(nhInstallationManager, times(1)).saveInstallation(installation_third, logSuccessListener, logFailureListener);
     }
 
     @Test
     public void DebouncerInvokesSaveTwice() throws InterruptedException {
         NotificationHubInstallationAdapter nhInstallationManager = mock(NotificationHubInstallationAdapter.class);
         DebounceInstallationAdapter debouncer = new DebounceInstallationAdapter(context, nhInstallationManager);
-        debouncer.saveInstallation(context, installation, logSuccessListener, logFailureListener);
+        debouncer.saveInstallation(installation, logSuccessListener, logFailureListener);
         Thread.sleep(debouncerDelayPlusSecond);
-        debouncer.saveInstallation(context, installation_second, logSuccessListener, logFailureListener);
+        debouncer.saveInstallation(installation_second, logSuccessListener, logFailureListener);
         Thread.sleep(debouncerDelayPlusSecond);
-        verify(nhInstallationManager, times(1)).saveInstallation(context, installation, logSuccessListener, logFailureListener);
-        verify(nhInstallationManager, times(1)).saveInstallation(context, installation_second, logSuccessListener, logFailureListener);
+        verify(nhInstallationManager, times(1)).saveInstallation(installation, logSuccessListener, logFailureListener);
+        verify(nhInstallationManager, times(1)).saveInstallation(installation_second, logSuccessListener, logFailureListener);
     }
 
     @Test
     public void DebouncerRestartsDelay() throws InterruptedException {
         NotificationHubInstallationAdapter nhInstallationManager = mock(NotificationHubInstallationAdapter.class);
         DebounceInstallationAdapter debouncer = new DebounceInstallationAdapter(context, nhInstallationManager);
-        debouncer.saveInstallation(context, installation, logSuccessListener, logFailureListener);
+        debouncer.saveInstallation(installation, logSuccessListener, logFailureListener);
         Thread.sleep(debouncerDelayInMillisec - 1000);
         // Invoke second call during delay, scheduler should be restarted, delay 2seconds
-        debouncer.saveInstallation(context, installation_second, logSuccessListener, logFailureListener);
+        debouncer.saveInstallation(installation_second, logSuccessListener, logFailureListener);
         Thread.sleep(1000);
-        verify(nhInstallationManager, times(0)).saveInstallation(context, installation, logSuccessListener, logFailureListener);
-        verify(nhInstallationManager, times(0)).saveInstallation(context, installation_second, logSuccessListener, logFailureListener);
+        verify(nhInstallationManager, times(0)).saveInstallation(installation, logSuccessListener, logFailureListener);
+        verify(nhInstallationManager, times(0)).saveInstallation(installation_second, logSuccessListener, logFailureListener);
         Thread.sleep(1000);
         // After 2 seconds recent installation should be saved
-        verify(nhInstallationManager, times(0)).saveInstallation(context, installation, logSuccessListener, logFailureListener);
-        verify(nhInstallationManager, times(1)).saveInstallation(context, installation_second, logSuccessListener, logFailureListener);
+        verify(nhInstallationManager, times(0)).saveInstallation(installation, logSuccessListener, logFailureListener);
+        verify(nhInstallationManager, times(1)).saveInstallation(installation_second, logSuccessListener, logFailureListener);
     }
 
     @Test
     public void DebouncerDoesNotInvokeSaveForSameInstallation() throws InterruptedException {
         NotificationHubInstallationAdapter nhInstallationManager = mock(NotificationHubInstallationAdapter.class);
         DebounceInstallationAdapter debouncer = new DebounceInstallationAdapter(context, nhInstallationManager);
-        debouncer.saveInstallation(context, installation, logSuccessListener, logFailureListener);
+        debouncer.saveInstallation(installation, logSuccessListener, logFailureListener);
         Thread.sleep(debouncerDelayPlusSecond);
-        debouncer.saveInstallation(context, installation, logSuccessListener, logFailureListener);
+        debouncer.saveInstallation(installation, logSuccessListener, logFailureListener);
         Thread.sleep(debouncerDelayPlusSecond);
-        verify(nhInstallationManager, times(1)).saveInstallation(context, installation, logSuccessListener, logFailureListener);
+        verify(nhInstallationManager, times(1)).saveInstallation(installation, logSuccessListener, logFailureListener);
     }
 
     @Test
     public void DebouncerSavesRecentToSharedPreferences() throws InterruptedException {
         NotificationHubInstallationAdapter nhInstallationManager = mock(NotificationHubInstallationAdapter.class);
         DebounceInstallationAdapter debouncer = new DebounceInstallationAdapter(context, nhInstallationManager);
-        debouncer.saveInstallation(context, installation, logSuccessListener, logFailureListener);
+        debouncer.saveInstallation(installation, logSuccessListener, logFailureListener);
         Thread.sleep(debouncerDelayPlusSecond);
 
         String PREFERENCE_KEY = "recentInstallation";

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/DebounceInstallationAdapter.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/DebounceInstallationAdapter.java
@@ -37,7 +37,7 @@ public class DebounceInstallationAdapter implements InstallationAdapter {
 
 
     @Override
-    public void saveInstallation(final Context context, final Installation installation, final Listener onSuccess, final ErrorListener onFailure) {
+    public void saveInstallation(final Installation installation, final Listener onSuccess, final ErrorListener onFailure) {
         if (mSchedFuture != null && !mSchedFuture.isDone()) {
             mSchedFuture.cancel(true);
         }
@@ -51,7 +51,7 @@ public class DebounceInstallationAdapter implements InstallationAdapter {
             @Override
             public void run() {
                 try {
-                    mInstallationAdapter.saveInstallation(context, installation, onSuccess, onFailure);
+                    mInstallationAdapter.saveInstallation(installation, onSuccess, onFailure);
                     mPreferences.edit().putInt(PREFERENCE_KEY, installation.hashCode()).apply();
                 } catch (Exception e) {
                     onFailure.onInstallationSaveError(e);

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/InstallationAdapter.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/InstallationAdapter.java
@@ -1,7 +1,5 @@
 package com.microsoft.windowsazure.messaging.notificationhubs;
 
-import android.content.Context;
-
 /**
  * Defines the operations that must implemented in order to communicate with a backend that is
  * keeps track of registered devices.
@@ -12,10 +10,9 @@ import android.content.Context;
 public interface InstallationAdapter {
     /**
      * Updates a backend with the updated Installation information for this device.
-     * @param context Application context.
      * @param installation The record to update.
      */
-    void saveInstallation(Context context, Installation installation, Listener onSuccess, ErrorListener onFailure);
+    void saveInstallation(Installation installation, Listener onSuccess, ErrorListener onFailure);
 
     /**
      * Defines the callback that should be invoked when an Installation is successfully processed by

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -79,6 +79,7 @@ public final class NotificationHub {
      */
     public static void initialize(Application application, String hubName, String connectionString) {
         initialize(application, new DebounceInstallationAdapter(application, new NotificationHubInstallationAdapter(
+                application,
                 hubName,
                 connectionString)));
     }
@@ -215,7 +216,7 @@ public final class NotificationHub {
         }
 
         if (mAdapter != null) {
-            mAdapter.saveInstallation(mApplication, installation, mOnSavedInstallation, mOnInstallationFailure);
+            mAdapter.saveInstallation(installation, mOnSavedInstallation, mOnInstallationFailure);
         }
     }
 

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHubInstallationAdapter.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHubInstallationAdapter.java
@@ -3,7 +3,6 @@ package com.microsoft.windowsazure.messaging.notificationhubs;
 import android.content.Context;
 import android.os.Build;
 import android.util.Base64;
-import android.util.Log;
 
 import com.microsoft.windowsazure.messaging.notificationhubs.http.HttpClient;
 import com.microsoft.windowsazure.messaging.notificationhubs.http.HttpResponse;
@@ -35,11 +34,12 @@ public class NotificationHubInstallationAdapter implements InstallationAdapter {
 
     private final String mHubName;
     private final ConnectionString mConnectionString;
-    private HttpClient httpClient;
+    private HttpClient mHttpClient;
 
-    public NotificationHubInstallationAdapter(String hubName, String connectionString) {
+    public NotificationHubInstallationAdapter(Context context, String hubName, String connectionString) {
         mHubName = hubName;
         mConnectionString = ConnectionString.parse(connectionString);
+        mHttpClient = HttpUtils.createHttpClient(context.getApplicationContext());
     }
 
     /**
@@ -48,13 +48,11 @@ public class NotificationHubInstallationAdapter implements InstallationAdapter {
      * @param installation The record to update.\
      */
     @Override
-    public void saveInstallation(final Context context, final Installation installation, final Listener onSuccess, final ErrorListener onFailure) {
-        httpClient = HttpUtils.createHttpClient(context.getApplicationContext());
-
+    public void saveInstallation(final Installation installation, final Listener onSuccess, final ErrorListener onFailure) {
         String formatEndpoint = NotificationHubInstallationHelper.parseSbEndpoint(mConnectionString.getEndpoint());
         final String url = NotificationHubInstallationHelper.getInstallationUrl(formatEndpoint, mHubName, installation.getInstallationId());
 
-        httpClient.callAsync(url, "PUT", getHeaders(url), buildCallTemplate(installation), buildServiceCallback(installation, onSuccess, onFailure));
+        mHttpClient.callAsync(url, "PUT", getHeaders(url), buildCallTemplate(installation), buildServiceCallback(installation, onSuccess, onFailure));
     }
 
     private String generateAuthToken(String url) throws InvalidKeyException {


### PR DESCRIPTION
Context is going often be an important asset for any `InstallationAdapter`. However, looking at other places in our code base and Android Volley, it's become pretty clear that the place it belongs
is in the constructor.