### PR TITLE
Adding a Cookbook for Applying ACP Device Properties as Tags

### DIFF
--- a/notification-hubs-test-app-refresh/src/androidTest/java/com/example/notification_hubs_test_app_refresh/cookbook/DevicePropertyProviderTest.java
+++ b/notification-hubs-test-app-refresh/src/androidTest/java/com/example/notification_hubs_test_app_refresh/cookbook/DevicePropertyProviderTest.java
@@ -1,0 +1,104 @@
+package com.example.notification_hubs_test_app_refresh.cookbook;
+
+import android.content.Context;
+
+import androidx.test.filters.SmallTest;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
+
+@SmallTest
+public class DevicePropertyProviderTest {
+
+    private final Context mContext = InstrumentationRegistry.getInstrumentation().getContext();
+
+    /**
+     * Provides the means to evaluate a string for compliance with ANH Tag limitations as published
+     * here:
+     *  https://docs.microsoft.com/en-us/azure/notification-hubs/notification-hubs-tags-segment-push-message#tags
+     */
+    private static final Pattern VALID_TAG_PATTERN = Pattern.compile("^[a-zA-Z0-9_@#\\.:\\-]{1,120}$");
+
+    @Test
+    public void getCountryTag() {
+        final String expectedPrefix = "Country_";
+        final Pattern VALID_COUNTRY_PATTERN = Pattern.compile("^"+ expectedPrefix + "[a-zA-Z]{2,3}$");
+
+        String countryTag = DevicePropertyProvider.getCountryTag();
+        Matcher acceptableTagMatcher = VALID_TAG_PATTERN.matcher(countryTag);
+        Matcher acceptableCountryMatcher = VALID_COUNTRY_PATTERN.matcher(countryTag);
+
+        Assert.assertTrue("Country tag must be a valid tag", acceptableTagMatcher.matches());
+        Assert.assertTrue("Country tag must start with \"" + expectedPrefix + "\"", countryTag.startsWith(expectedPrefix));
+        Assert.assertTrue("Country tag must return a two letter country code, or a three letter region code", acceptableCountryMatcher.matches());
+    }
+
+    @Test
+    public void getLanguageTag() {
+        final String expectedPrefix = "Language_";
+        final String languageTerm = "([a-zA-Z0-9]{2,3})";
+        final String scriptTerm = "(-[a-zA-Z0-9]{4})?";
+        final String regionTerm = "(-(?:[a-zA-Z0-9]{2}|[0-9]{3}))?";
+        // There are others terms (variant, extension, and privateuse) that are too obscure to test here unless we hear from customers.
+        final Pattern VALID_LANGUAGE_PATTERN = Pattern.compile(
+                "^" +
+                expectedPrefix +
+                languageTerm +
+                scriptTerm +
+                regionTerm +
+                "$");
+
+        String languageTag = DevicePropertyProvider.getLanguageTag();
+        Matcher acceptableTagMatcher = VALID_TAG_PATTERN.matcher(languageTag);
+        Matcher acceptableLanguageMatcher = VALID_LANGUAGE_PATTERN.matcher(languageTag);
+
+        Assert.assertTrue("Language tag must be a valid tag", acceptableTagMatcher.matches());
+        Assert.assertTrue("Language tag must start with \"" + expectedPrefix + "\"", languageTag.startsWith(expectedPrefix));
+        Assert.assertTrue("Language tag must comply with RFC5646", acceptableLanguageMatcher.matches());
+    }
+
+    @Test
+    public void getCarrierTag() {
+        final String expectedPrefix = "MobileCarrier_";
+
+        String carrierTag = DevicePropertyProvider.getCarrierTag(mContext);
+        Matcher acceptableTagMatcher = VALID_TAG_PATTERN.matcher(carrierTag);
+
+        Assert.assertTrue("Carrier tag must be a valid tag", acceptableTagMatcher.matches());
+        Assert.assertTrue("Carrier tag must start with \"" + expectedPrefix + "\"", carrierTag.startsWith(expectedPrefix));
+        // At time of authoring, the behavior when a phone has no carrier is undefined. No assertion
+        // to make sure there is actually a carrier listed.
+    }
+
+    @Test
+    public void getOemTag() {
+        final String expectedPrefix = "Oem_";
+
+        String oemTag = DevicePropertyProvider.getOemTag(mContext);
+        Matcher acceptableTagMatcher = VALID_TAG_PATTERN.matcher(oemTag);
+
+        Assert.assertTrue("OEM tag must be a valid tag.", acceptableTagMatcher.matches());
+        Assert.assertTrue("OEM tag must start with \"" + expectedPrefix + "\"", oemTag.startsWith(expectedPrefix));
+        Assert.assertTrue("OEM tag must be populated", oemTag.length() > expectedPrefix.length());
+    }
+
+    @Test
+    public void getScreenSizeTag() {
+        final String expectedPrefix = "ScreenSize_";
+        final Pattern VALID_SCREEN_SIZE_PATTERN = Pattern.compile("^" + expectedPrefix + "[1-9]\\d*X[1-9]\\d*$");
+
+        String screenSizeTag = DevicePropertyProvider.getScreenSizeTag(mContext);
+        Matcher acceptableTagMatcher = VALID_TAG_PATTERN.matcher(screenSizeTag);
+        Matcher acceptableScreenSizerMatcher = VALID_SCREEN_SIZE_PATTERN.matcher(screenSizeTag);
+
+        Assert.assertTrue("Screen size tag must be a valid tag.", acceptableTagMatcher.matches());
+        Assert.assertTrue("Screen size tag must start with \"" + expectedPrefix + "\"", screenSizeTag.startsWith(expectedPrefix));
+        Assert.assertTrue("Screen size must adhere to {width}X{height} without prefixing zeros.", acceptableScreenSizerMatcher.matches());
+    }
+}

--- a/notification-hubs-test-app-refresh/src/main/java/com/example/notification_hubs_test_app_refresh/cookbook/DevicePropertyProvider.java
+++ b/notification-hubs-test-app-refresh/src/main/java/com/example/notification_hubs_test_app_refresh/cookbook/DevicePropertyProvider.java
@@ -1,0 +1,98 @@
+package com.example.notification_hubs_test_app_refresh.cookbook;
+
+import android.app.Activity;
+import android.content.Context;
+import android.graphics.Point;
+import android.os.Build;
+import android.telephony.TelephonyManager;
+import android.view.Display;
+import android.view.Surface;
+import android.view.WindowManager;
+
+import java.util.Locale;
+
+/**
+ * Examples that are ready for copy/paste usage of how to get particular data about the device this
+ * application is running on.
+ */
+public class DevicePropertyProvider {
+    /**
+     * Returns a tag that is normalized across platforms, to allow targeting of any device in a
+     * particular country.
+     *
+     * @return A string that can be used to target devices in a country.
+     */
+    public static String getCountryTag() {
+        return "Country_" + Locale.getDefault().getCountry();
+    }
+
+    /**
+     * Returns a tag that is normalized across platforms, to allow targeting of any device where the
+     * user locale is set to a particular language.
+     * @return A string that can be used to target device using a language.
+     */
+    public static String getLanguageTag() {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns a tag that is normalized across platforms to allow targeting of any device connected
+     * to a particular mobile carrier's network.
+     * @param context The Application context.
+     * @return A string that can be used to target devices on a particular mobile network.
+     */
+    public static String getCarrierTag(Context context) {
+        TelephonyManager manager = (TelephonyManager)context.getSystemService(Context.TELEPHONY_SERVICE);
+        String carrierName = manager.getNetworkOperatorName();
+
+        return "MobileCarrier_" + carrierName;
+    }
+
+    /**
+     * Returns a tag that allows for the targeting to all devices made by a particular company.
+     * @param context The Application context.
+     * @return A string that can be used to target devices manufactured by a given company.
+     */
+    public static String getOemTag(Context context) {
+        return "Oem_" + Build.MANUFACTURER;
+    }
+
+    /**
+     * Returns a tag that is normalized across platforms to allow for the targeting of any device
+     * with a specific screen-size.
+     *
+     * The resolution that is used will reflect the device's screen resolution minus any permanent
+     * graphical elements. Further, width and height will reflect the devices' un-rotated position.
+     *
+     * @param context The Application context.
+     * @return A string that contains the screen dimensions of the current device.
+     */
+    public static String getScreenSizeTag(Context context) {
+        WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+        Display disp = wm.getDefaultDisplay();
+        Point resolution = new Point();
+        disp.getSize(resolution);
+
+        switch (disp.getRotation()) {
+            case Surface.ROTATION_90:
+            case Surface.ROTATION_270:
+                resolution.set(resolution.y, resolution.x);
+                break;
+            case Surface.ROTATION_0:
+            case Surface.ROTATION_180:
+                // Intentionally Left Blank
+                break;
+            default:
+                throw new IllegalStateException("Screen-size can only be determined when screen is rotated at a right-angle");
+        }
+
+        StringBuilder builder = new StringBuilder("ScreenSize_");
+        builder.append(resolution.x);
+        builder.append('X');
+        builder.append(resolution.y);
+        return builder.toString();
+    }
+
+
+}

--- a/notification-hubs-test-app-refresh/src/main/java/com/example/notification_hubs_test_app_refresh/cookbook/DevicePropertyProvider.java
+++ b/notification-hubs-test-app-refresh/src/main/java/com/example/notification_hubs_test_app_refresh/cookbook/DevicePropertyProvider.java
@@ -32,8 +32,13 @@ public class DevicePropertyProvider {
      * @return A string that can be used to target device using a language.
      */
     public static String getLanguageTag() {
-        // TODO
-        throw new UnsupportedOperationException();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            return "Language_" + Locale.getDefault().toLanguageTag();
+        }
+
+        // Do you need this value to be populated in Android versions before Lollipop? Please tell us at:
+        // https://github.com/Azure/azure-notificationhubs-android/issues
+        throw new UnsupportedOperationException("Language tag logic was added to the Android standard library in API Level 21 (Lollipop)");
     }
 
     /**
@@ -93,6 +98,4 @@ public class DevicePropertyProvider {
         builder.append(resolution.y);
         return builder.toString();
     }
-
-
 }


### PR DESCRIPTION
Adds code to help folks using App Center Push's SDK easily add tags that correspond to Device Properties. This cookbook will be standardized across SDKs, so that things like language and country will be populated consistently regardless of whether your app is running on iOS or Android.