### PR TITLE
Fixed string comparison bug found while reading docs

### DIFF
--- a/FCMTutorialApp/src/main/java/com/microsoft/notificationhubs/fcmtutorialapp/RegistrationIntentService.java
+++ b/FCMTutorialApp/src/main/java/com/microsoft/notificationhubs/fcmtutorialapp/RegistrationIntentService.java
@@ -52,7 +52,7 @@ public class RegistrationIntentService extends IntentService {
             }
 
             // Check if the token may have been compromised and needs refreshing.
-            else if ((storedToken=sharedPreferences.getString("FCMtoken", "")) != FCM_token) {
+            else if (!(storedToken = sharedPreferences.getString("FCMtoken", "")).equals(FCM_token)) {
 
                 NotificationHub hub = new NotificationHub(NotificationSettings.HubName,
                         NotificationSettings.HubListenConnectionString, this);

--- a/notification-hubs-test-app/src/main/java/com/microsoft/notification_hubs_test_app/RegistrationIntentService.java
+++ b/notification-hubs-test-app/src/main/java/com/microsoft/notification_hubs_test_app/RegistrationIntentService.java
@@ -52,7 +52,7 @@ public class RegistrationIntentService extends IntentService {
 
                 sharedPreferences.edit().putString("registrationID", regID ).apply();
                 sharedPreferences.edit().putString("FCMtoken", FCM_token ).apply();
-            } else if ((storedToken = sharedPreferences.getString("FCMtoken", "")) != FCM_token) {
+            } else if (!(storedToken = sharedPreferences.getString("FCMtoken", "")).equals(FCM_token)) {
 
                 NotificationHub hub = new NotificationHub(BuildConfig.hubName,
                         BuildConfig.hubListenConnectionString, this);


### PR DESCRIPTION
I was reading [these docs](https://docs.microsoft.com/en-us/azure/notification-hubs/notification-hubs-android-push-notification-google-fcm-get-started) and noticed this if statement was checking String equivalency incorrectly when I walked through my code. The value was the same but the branch was entered. Strings in Java need value comparisons using the `.equals` method so I adapted it to use that with a not `!` operator. It seems to work as intended now.

I submitted a docs correction PR also for it.

Thanks