### PR TITLE
NotificationHub.initialize -> NotificationHub.start

### DIFF
--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -75,9 +75,8 @@ public final class NotificationHub {
      * @param hubName The name of the Notification Hub that will broadcast notifications to this
      *                device.
      * @param connectionString The Listen-only AccessPolicy that grants this device the ability to
-     *                         receive notifications.
      */
-    public static void initialize(Application application, String hubName, String connectionString) {
+    public static void start(Application application, String hubName, String connectionString) {
         InstallationAdapter client = new NotificationHubInstallationAdapter(
                 application,
                 hubName,

--- a/notification-hubs-test-app-java/src/main/java/com/example/notification_hubs_test_app_java/MainActivity.java
+++ b/notification-hubs-test-app-java/src/main/java/com/example/notification_hubs_test_app_java/MainActivity.java
@@ -21,7 +21,7 @@ public class MainActivity extends AppCompatActivity {
         TabLayout tabs = findViewById(R.id.tabs);
         tabs.setupWithViewPager(viewPager);
 
-        NotificationHub.initialize(this.getApplication(), BuildConfig.hubName, BuildConfig.hubListenConnectionString);
+        NotificationHub.start(this.getApplication(), BuildConfig.hubName, BuildConfig.hubListenConnectionString);
         NotificationHub.addTag("userAgent:com.example.notification_hubs_test_app_java:0.1.0");
         InstallationTemplate testTemplate = new InstallationTemplate();
         testTemplate.setBody("{\"data\":{\"message\":\"Notification Hub test notification: $myTextProp\"}}");


### PR DESCRIPTION
This will drive conformance with the Apple SDK, and keeps the notion of a `stop` method available and more intuitive for the future.