### PR TITLE
Isolate `DebouncerAdapter` From Downstream Adapters

### DIFF
--- a/notification-hubs-sdk/src/androidTest/java/com/microsoft/windowsazure/messaging/notificationhubs/DebouncerTest.java
+++ b/notification-hubs-sdk/src/androidTest/java/com/microsoft/windowsazure/messaging/notificationhubs/DebouncerTest.java
@@ -14,18 +14,12 @@ import org.junit.Test;
 import java.util.Date;
 import java.util.Random;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
-
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.withSettings;
+import static org.mockito.Mockito.verify;
 
 @SmallTest
 public class DebouncerTest {
@@ -129,7 +123,7 @@ public class DebouncerTest {
 
     @Test
     public void DebouncerDoesNotInvokeSaveForSameInstallation() throws InterruptedException {
-        NotificationHubInstallationAdapter nhInstallationManager = mock(NotificationHubInstallationAdapter.class, withSettings());
+        NotificationHubInstallationAdapter nhInstallationManager = mock(NotificationHubInstallationAdapter.class);
         DebounceInstallationAdapter debouncer = new DebounceInstallationAdapter(context, nhInstallationManager);
         debouncer.saveInstallation(installation, logSuccessListener, logFailureListener);
         Thread.sleep(debouncerDelayPlusSecond);

--- a/notification-hubs-sdk/src/androidTest/java/com/microsoft/windowsazure/messaging/notificationhubs/DebouncerTest.java
+++ b/notification-hubs-sdk/src/androidTest/java/com/microsoft/windowsazure/messaging/notificationhubs/DebouncerTest.java
@@ -7,9 +7,15 @@ import androidx.test.filters.SmallTest;
 
 import com.microsoft.windowsazure.messaging.R;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Date;
+import java.util.Random;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -19,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.withSettings;
 
 @SmallTest
 public class DebouncerTest {
@@ -122,7 +129,7 @@ public class DebouncerTest {
 
     @Test
     public void DebouncerDoesNotInvokeSaveForSameInstallation() throws InterruptedException {
-        NotificationHubInstallationAdapter nhInstallationManager = mock(NotificationHubInstallationAdapter.class);
+        NotificationHubInstallationAdapter nhInstallationManager = mock(NotificationHubInstallationAdapter.class, withSettings());
         DebounceInstallationAdapter debouncer = new DebounceInstallationAdapter(context, nhInstallationManager);
         debouncer.saveInstallation(installation, logSuccessListener, logFailureListener);
         Thread.sleep(debouncerDelayPlusSecond);
@@ -142,5 +149,36 @@ public class DebouncerTest {
         int recentHash = mPreferences.getInt(DebounceInstallationAdapter.LAST_ACCEPTED_HASH_KEY,0);
 
         assertTrue(recentHash == installation.hashCode());
+    }
+
+    @Test
+    public void DebounceResilientToInstallationAdapterModifications() throws InterruptedException {
+        Random r = new Random();
+        final Installation modifiableInstallation = new Installation();
+        modifiableInstallation.setPushChannel("faux_push_channel");
+        modifiableInstallation.setInstallationId("id_" + r.nextLong());
+        int hashBeforeAdapter = modifiableInstallation.hashCode();
+        final Semaphore adapterStatus = new Semaphore(0);
+
+        InstallationAdapter saboteur = new InstallationAdapter() {
+            @Override
+            public void saveInstallation(Installation installation, Listener onInstallationSaved, ErrorListener onInstallationSaveError) {
+                Assert.assertSame(modifiableInstallation, installation); // If this is failing, the test is malformed. Consider fixing the test, not the Debouncer.
+                installation.setExpiration(new Date());
+                onInstallationSaved.onInstallationSaved(installation);
+                adapterStatus.release();
+            }
+        };
+
+        DebounceInstallationAdapter debouncer = new DebounceInstallationAdapter(context, saboteur);
+        debouncer.saveInstallation(modifiableInstallation, logSuccessListener, logFailureListener);
+        adapterStatus.acquire();
+
+        int hashAfterAdapter = modifiableInstallation.hashCode();
+
+        int savedHash = debouncer.getLastAcceptedHash();
+
+        Assert.assertNotEquals("Test is built to assume hash is modified", hashBeforeAdapter, hashAfterAdapter);
+        Assert.assertEquals("The hash which is saved by the DebouncerAdapter should not be influenced by Adapters that come after it.", hashBeforeAdapter, savedHash);
     }
 }

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/DebounceInstallationAdapter.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/DebounceInstallationAdapter.java
@@ -101,4 +101,12 @@ public class DebounceInstallationAdapter implements InstallationAdapter {
             }
         }, mInterval, TimeUnit.MILLISECONDS);
     }
+
+    long getLastAcceptedTimestamp() {
+        return mPreferences.getLong(LAST_ACCEPTED_TIMESTAMP_KEY, Long.MIN_VALUE);
+    }
+
+    int getLastAcceptedHash() {
+        return mPreferences.getInt(LAST_ACCEPTED_HASH_KEY, 0);
+    }
 }

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/DebounceInstallationAdapter.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/DebounceInstallationAdapter.java
@@ -76,12 +76,12 @@ public class DebounceInstallationAdapter implements InstallationAdapter {
             mSchedFuture.cancel(true);
         }
 
-        int recentHash = mPreferences.getInt(LAST_ACCEPTED_HASH_KEY, 0);
-        long lastAcceptedTimestamp = mPreferences.getLong(LAST_ACCEPTED_TIMESTAMP_KEY, Long.MIN_VALUE);
+        final int currentHash = installation.hashCode();
+        int recentHash = getLastAcceptedHash();
 
-        boolean sameAsLastAccepted = recentHash != 0 && recentHash == installation.hashCode();
+        boolean sameAsLastAccepted = recentHash != 0 && recentHash == currentHash;
         final long currentTime = new Date().getTime();
-        boolean lastAcceptedIsRecent =  currentTime < lastAcceptedTimestamp + mInstallationStaleMillis;
+        boolean lastAcceptedIsRecent =  currentTime < getLastAcceptedTimestamp() + mInstallationStaleMillis;
 
         if (sameAsLastAccepted && lastAcceptedIsRecent) {
             return;
@@ -93,7 +93,7 @@ public class DebounceInstallationAdapter implements InstallationAdapter {
             public void run() {
                 try {
                     mInstallationAdapter.saveInstallation(installation, onInstallationSaved, onInstallationSaveError);
-                    mPreferences.edit().putInt(LAST_ACCEPTED_HASH_KEY, installation.hashCode()).apply();
+                    mPreferences.edit().putInt(LAST_ACCEPTED_HASH_KEY, currentHash).apply();
                     mPreferences.edit().putLong(LAST_ACCEPTED_TIMESTAMP_KEY, currentTime).apply();
                 } catch (Exception e) {
                     onInstallationSaveError.onInstallationSaveError(e);


### PR DESCRIPTION
This change fixes a scenario where the `DebouncerAdapter` gets tricked into accepting duplicates when a downstream adapter changes the installation being processed.

Related to #94 