### PR TITLE
Update DebouncerTest to use Semaphore to detect when test conditions have been met

### DIFF
--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/DebounceInstallationAdapter.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/DebounceInstallationAdapter.java
@@ -71,7 +71,7 @@ public class DebounceInstallationAdapter implements InstallationAdapter {
     }
 
     @Override
-    public void saveInstallation(final Installation installation, final Listener onInstallationSaved, final ErrorListener onInstallationSaveError) {
+    public synchronized void saveInstallation(final Installation installation, final Listener onInstallationSaved, final ErrorListener onInstallationSaveError) {
         if (mSchedFuture != null && !mSchedFuture.isDone()) {
             mSchedFuture.cancel(true);
         }
@@ -86,7 +86,6 @@ public class DebounceInstallationAdapter implements InstallationAdapter {
         if (sameAsLastAccepted && lastAcceptedIsRecent) {
             return;
         }
-
 
         mSchedFuture = mScheduler.schedule(new Runnable() {
             @Override


### PR DESCRIPTION
This allows us to use semaphores to detect when it is safe to proceed instead of relying on waiting some duration of time. This makes for more reliable and faster tests. Plus, no mocks.