### PR TITLE
Touch ups

### DIFF
--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/DebounceInstallationAdapter.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/DebounceInstallationAdapter.java
@@ -73,7 +73,7 @@ public class DebounceInstallationAdapter implements InstallationAdapter {
      * otherwise been a duplicate {@link Installation} through.
      * @param millis The number of milliseconds before an {@link Installation} should be considered stale.
      */
-    public void setInstallationStaleWindow(long millis) {
+    void setInstallationStaleWindow(long millis) {
         mInstallationStaleMillis = millis;
     }
 

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -83,7 +83,7 @@ public final class NotificationHub {
                 connectionString);
         InstallationAdapter debouncer = new DebounceInstallationAdapter(application, client);
 
-        initialize(application, debouncer);
+        start(application, debouncer);
     }
 
     /**
@@ -96,7 +96,7 @@ public final class NotificationHub {
      *                needs access to.
      * @param adapter A client that can create/overwrite a reference to this device with a backend.
      */
-    public static void initialize(Application application, InstallationAdapter adapter) {
+    public static void start(Application application, InstallationAdapter adapter) {
         final NotificationHub instance = getInstance();
         instance.mAdapter = adapter;
         instance.mApplication = application;


### PR DESCRIPTION
- Mark DebounceInstallationAdapter.setInstallationStaleWindow as package protected. This will reduce our public surface area to allow Debouncer to be split into Debounce and De-dupe layers in the future without a breaking change.
- Fixing missed occurrence of `initialize` that should have been renamed to `start`.