### PR TITLE
Installation.setInstallationId -> public

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ _{project-root}/{your-module}/build.gradle:_
 
 dependencies {
     // Ensure the following line is included in your app/library's "dependencies" section.
-    implementation 'com.microsoft.azure:notification-hubs-android-sdk:v1.0.0'
+    implementation 'com.microsoft.azure:notification-hubs-android-sdk:v1.0.1'
 }
 ```
 

--- a/notification-hubs-sdk/build.gradle
+++ b/notification-hubs-sdk/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 
-def VERSION = '1.0.0'
+def VERSION = '1.0.1'
 def PUBLISH_ARTIFACT_ID = 'notification-hubs-android-sdk'
 def GROUP_ID = 'com.microsoft.azure'
 

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/Installation.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/Installation.java
@@ -54,7 +54,7 @@ public class Installation implements Taggable {
      * Device.
      * @param id The unique identifer to associate with the record of this device.
      */
-    void setInstallationId(String id) {
+    public void setInstallationId(String id) {
         mInstallationId = id;
     }
 


### PR DESCRIPTION
Without having access to this method, folks writing their own visitors cannot change the InstallationId. This is impeding the XPlat Xamarin SDK from building an abstraction.

Fixes #112 