### PR TITLE
Removing explict FirebaseReceiver start

### DIFF
--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -115,9 +115,6 @@ public final class NotificationHub {
         instance.mPushChannelVisitor = new PushChannelVisitor(instance.mApplication);
         instance.useInstanceVisitor(instance.mPushChannelVisitor);
 
-        Intent i =  new Intent(application, FirebaseReceiver.class);
-        application.startService(i);
-
         // Why is this done here instead of being in the manifest like everything else?
         // BroadcastReceivers are special, and starting in Android 8.0 the ability to start them
         // from the manifest was removed. See documentation from Google here:


### PR DESCRIPTION
## Description

Remove the NotificationHub global single instance's explicit call to start the FirebaseReceiver. This should spare our customers a exception that gets thrown if it is called from the background, while also removing a small piece of coupling between the two classes.

## Related PRs or issues

Fixes #116 

## Misc

I tested in the emulator using the Java sample application, and confirmed that we still receive notifications in both the foreground and background.