### PR TITLE
Fixing Firebase initialization race condition.

### DIFF
--- a/notification-hubs-sdk/src/main/AndroidManifest.xml
+++ b/notification-hubs-sdk/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
             android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
+                <action android:name="com.google.firebase.messaging.NEW_TOKEN" />
             </intent-filter>
         </service>
     </application>

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
@@ -46,7 +46,6 @@ public final class FirebaseReceiver extends FirebaseMessagingService {
     public void onCreate() {
         super.onCreate();
 
-        Log.d("ANH", "Firebase is about to register the application");
         mHub.registerApplication(this.getApplication());
 
         if (mHub.getPushChannel() == null) {

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
@@ -46,6 +46,8 @@ public final class FirebaseReceiver extends FirebaseMessagingService {
     public void onCreate() {
         super.onCreate();
 
+        Log.d("ANH", "Firebase is about to register the application");
+        mHub.registerApplication(this.getApplication());
 
         if (mHub.getPushChannel() == null) {
             FirebaseInstanceId.getInstance()

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -68,6 +68,31 @@ public final class NotificationHub {
         return sInstance;
     }
 
+     synchronized void registerApplication(Application application) {
+        if (mApplication == application) {
+            return;
+        }
+
+        mApplication = application;
+
+        mPreferences = mApplication.getSharedPreferences(mApplication.getString(R.string.installation_enrichment_file_key), Context.MODE_PRIVATE);
+
+        mIdAssignmentVisitor = new IdAssignmentVisitor(mApplication);
+        useInstanceVisitor(mIdAssignmentVisitor);
+
+        mTagVisitor = new TagVisitor(mApplication);
+        useInstanceVisitor(mTagVisitor);
+
+        mTemplateVisitor = new TemplateVisitor(mApplication);
+        useInstanceVisitor(mTemplateVisitor);
+
+        mPushChannelVisitor = new PushChannelVisitor(mApplication);
+        useInstanceVisitor(mPushChannelVisitor);
+
+        mUserIdVisitor = new UserIdVisitor(mApplication);
+        useInstanceVisitor(mUserIdVisitor);
+    }
+
     /**
      * Initialize the single global instance of {@link NotificationHub} and configure to associate
      * this device with an Azure Notification Hub.
@@ -100,24 +125,8 @@ public final class NotificationHub {
     public static void start(Application application, InstallationAdapter adapter) {
         final NotificationHub instance = getInstance();
         instance.mAdapter = adapter;
-        instance.mApplication = application;
 
-        instance.mPreferences = instance.mApplication.getSharedPreferences(instance.mApplication.getString(R.string.installation_enrichment_file_key), Context.MODE_PRIVATE);
-
-        instance.mIdAssignmentVisitor = new IdAssignmentVisitor(instance.mApplication);
-        instance.useInstanceVisitor(instance.mIdAssignmentVisitor);
-
-        instance.mTagVisitor = new TagVisitor(instance.mApplication);
-        instance.useInstanceVisitor(instance.mTagVisitor);
-
-        instance.mTemplateVisitor = new TemplateVisitor(instance.mApplication);
-        instance.useInstanceVisitor(instance.mTemplateVisitor);
-
-        instance.mPushChannelVisitor = new PushChannelVisitor(instance.mApplication);
-        instance.useInstanceVisitor(instance.mPushChannelVisitor);
-
-        instance.mUserIdVisitor = new UserIdVisitor(instance.mApplication);
-        instance.useInstanceVisitor(instance.mUserIdVisitor);
+        instance.registerApplication(application);
 
         // Why is this done here instead of being in the manifest like everything else?
         // BroadcastReceivers are special, and starting in Android 8.0 the ability to start them


### PR DESCRIPTION
The `NotificationHub` global single instance needs to have a reference to the Application in order to load `SharedPreferences`. Before this change, the only time we could get access to that Application was through the User's code calling us from an Activity or Service. In some situations, like the one described in #123, `FirebaseReceiver` was being initialized before it made sense for the customer to call `NotificationHub.start()`. In that case, `NotificationHub` was uninitialized, and `FirebaseReceiver` crashes with a `NullReferenceException`, inhibiting further usage. By refactoring the actual visitor population out, it allows either `FirebaseReceiver` or the customer to win the race and initialize `NotificationHub`.