### PR TITLE
Adding detail to NotificationHubExcetion message.

### DIFF
--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHubException.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHubException.java
@@ -13,7 +13,7 @@ public class NotificationHubException extends Exception {
     private final Map<String, String> mResponseHeaders;
 
     NotificationHubException(NetworkResponse networkResponse) {
-        super("Azure Notification Hub rejected the request.");
+        super("Azure Notification Hub request failed with status " + networkResponse.statusCode + ": " + new String(networkResponse.data));
         mResponseBody = networkResponse.data;
         mResponseStatusCode = networkResponse.statusCode;
         mResponseHeaders = networkResponse.headers;


### PR DESCRIPTION
Previously, response information like status code and body were buried in the Exception type. This change adds those details to the foreground by adding them the [Exception Message](https://docs.oracle.com/javase/7/docs/api/java/lang/Throwable.html#getMessage()).