### PR TITLE
Build both FCM + General SKU Artifacts in CI

### DIFF
--- a/.pipelines/pipeline.android.yaml
+++ b/.pipelines/pipeline.android.yaml
@@ -73,7 +73,7 @@ steps:
   displayName: 'Create assets for publication'
   inputs:
     options: '-PisCI="true"'
-    tasks: 'makeJar notification-hubs-sdk:publishGeneralPublicationToBuildDirRepository notification-hubs-sdk:writeVersionFile'
+    tasks: 'makeJar notification-hubs-sdk:publishGeneralPublicationToBuildDirRepository notification-hubs-sdk:publishFcmPublicationToBuildDirRepository notification-hubs-sdk:writeVersionFile'
     publishJUnitResults: false
 
 

--- a/.pipelines/pipeline.android.yaml
+++ b/.pipelines/pipeline.android.yaml
@@ -73,7 +73,7 @@ steps:
   displayName: 'Create assets for publication'
   inputs:
     options: '-PisCI="true"'
-    tasks: 'makeJar notification-hubs-sdk:publishReleasePublicationToBuildDirRepository notification-hubs-sdk:writeVersionFile'
+    tasks: 'makeJar notification-hubs-sdk:publishGeneralPublicationToBuildDirRepository notification-hubs-sdk:writeVersionFile'
     publishJUnitResults: false
 
 

--- a/notification-hubs-sdk/build.gradle
+++ b/notification-hubs-sdk/build.gradle
@@ -117,6 +117,13 @@ afterEvaluate {
 
                 from components.generalRelease
             }
+            fcm(MavenPublication) {
+                groupId = GROUP_ID
+                artifactId = PUBLISH_ARTIFACT_ID + '-fcm'
+                version = VERSION
+
+                from components.fcmRelease
+            }
         }
         repositories {
             maven {

--- a/notification-hubs-sdk/build.gradle
+++ b/notification-hubs-sdk/build.gradle
@@ -110,12 +110,12 @@ makeJar.dependsOn(clearJar, build)
 afterEvaluate {
     publishing {
         publications {
-            release(MavenPublication) {
+            general(MavenPublication) {
                 groupId = GROUP_ID
                 artifactId = PUBLISH_ARTIFACT_ID
                 version = VERSION
 
-                from components.fcmRelease
+                from components.generalRelease
             }
         }
         repositories {


### PR DESCRIPTION
Now that we have multiple source sets to indicate the SKU of the SDK, we should build and release both.