### PR TITLE
Remove AndroidX.AppCompat in Library

### DIFF
--- a/notification-hubs-sdk/build.gradle
+++ b/notification-hubs-sdk/build.gradle
@@ -62,7 +62,6 @@ configurations {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.android.volley:volley:1.1.1'
     fcmApi 'com.google.firebase:firebase-messaging:21.0.0'
     generalApi 'com.google.firebase:firebase-messaging:21.0.0'

--- a/notification-hubs-sdk/build.gradle
+++ b/notification-hubs-sdk/build.gradle
@@ -63,8 +63,8 @@ configurations {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.volley:volley:1.1.1'
-    fcmApi 'com.google.firebase:firebase-messaging:21.0.0'
-    generalApi 'com.google.firebase:firebase-messaging:21.0.0'
+    fcmApi 'com.google.firebase:firebase-messaging:21.0.1'
+    generalApi 'com.google.firebase:firebase-messaging:21.0.1'
 
     javadocDeps 'com.android.support:support-annotations:28.0.0'
 


### PR DESCRIPTION
This seems to be unnecessary bloat, a library like this one shouldn't be demanding UI component support.