### PR TITLE
More Aggressively Fetch Firebase Token on Start-Up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ captures/
 
 # Google Services (e.g. APIs or Firebase)
 google-services.json
+secrets.properties
 
 # Freeline
 freeline.py

--- a/notification-hubs-sdk/src/fcm/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
+++ b/notification-hubs-sdk/src/fcm/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
@@ -6,9 +6,8 @@ import androidx.annotation.NonNull;
 
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
+import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.iid.InstanceIdResult;
-import com.google.firebase.installations.FirebaseInstallations;
-import com.google.firebase.installations.InstallationTokenResult;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
@@ -49,18 +48,17 @@ public final class FirebaseReceiver extends FirebaseMessagingService {
 
         mHub.registerApplication(this.getApplication());
 
-        FirebaseInstallations.getInstance().getToken(true)
-            .addOnCompleteListener(new OnCompleteListener<InstallationTokenResult>() {
-                    @Override
-                    public void onComplete(@NonNull Task<InstallationTokenResult> task) {
-                if (!task.isSuccessful()) {
-                    Log.e("ANH", "unable to fetch FirebaseInstanceId");
-                    return;
+        FirebaseInstanceId.getInstance().getInstanceId()
+            .addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
+                @Override
+                public void onComplete(@NonNull Task<InstanceIdResult> task) {
+                    if (!task.isSuccessful()) {
+                        Log.e("ANH", "unable to fetch FirebaseInstanceId");
+                        return;
+                     }
+                     mHub.setInstancePushChannel(task.getResult().getToken());
                 }
-
-                mHub.setInstancePushChannel(task.getResult().getToken());
-                }
-                });
+            });
     }
 
     /**
@@ -79,6 +77,7 @@ public final class FirebaseReceiver extends FirebaseMessagingService {
      */
     @Override
     public void onNewToken(@NonNull String s) {
+        Log.i("ANH", "A new token has been issued by Firebase");
         mHub.setInstancePushChannel(s);
     }
 }

--- a/notification-hubs-sdk/src/fcm/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
+++ b/notification-hubs-sdk/src/fcm/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
@@ -49,20 +49,18 @@ public final class FirebaseReceiver extends FirebaseMessagingService {
 
         mHub.registerApplication(this.getApplication());
 
-        if (mHub.getInstancePushChannel() == null) {
-            FirebaseInstallations.getInstance().getToken(true)
-                    .addOnCompleteListener(new OnCompleteListener<InstallationTokenResult>() {
-                        @Override
-                        public void onComplete(@NonNull Task<InstallationTokenResult> task) {
-                            if (!task.isSuccessful()) {
-                                Log.e("ANH", "unable to fetch FirebaseInstanceId");
-                                return;
-                            }
+        FirebaseInstallations.getInstance().getToken(true)
+            .addOnCompleteListener(new OnCompleteListener<InstallationTokenResult>() {
+                    @Override
+                    public void onComplete(@NonNull Task<InstallationTokenResult> task) {
+                if (!task.isSuccessful()) {
+                    Log.e("ANH", "unable to fetch FirebaseInstanceId");
+                    return;
+                }
 
-                            mHub.setInstancePushChannel(task.getResult().getToken());
-                        }
-                    });
-        }
+                mHub.setInstancePushChannel(task.getResult().getToken());
+                }
+                });
     }
 
     /**

--- a/notification-hubs-sdk/src/fcm/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
+++ b/notification-hubs-sdk/src/fcm/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
@@ -51,14 +51,15 @@ public final class FirebaseReceiver extends FirebaseMessagingService {
 
         FirebaseInstallations.getInstance().getToken(true)
             .addOnCompleteListener(new OnCompleteListener<InstallationTokenResult>() {
-                public void onComplete(@NonNull Task<InstallationTokenResult> task) {
-                    if (!task.isSuccessful()) {
-                        Log.e("ANH", "unable to fetch FirebaseInstanceId");
-                        return;
-                    }
+                    @Override
+                    public void onComplete(@NonNull Task<InstallationTokenResult> task) {
+                if (!task.isSuccessful()) {
+                    Log.e("ANH", "unable to fetch FirebaseInstanceId");
+                    return;
+                }
 
-                    mHub.setInstancePushChannel(task.getResult().getToken());
-                    }
+                mHub.setInstancePushChannel(task.getResult().getToken());
+                }
                 });
     }
 

--- a/notification-hubs-sdk/src/fcm/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
+++ b/notification-hubs-sdk/src/fcm/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
@@ -6,8 +6,9 @@ import androidx.annotation.NonNull;
 
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.iid.InstanceIdResult;
+import com.google.firebase.installations.FirebaseInstallations;
+import com.google.firebase.installations.InstallationTokenResult;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
@@ -49,15 +50,15 @@ public final class FirebaseReceiver extends FirebaseMessagingService {
         mHub.registerApplication(this.getApplication());
 
         if (mHub.getInstancePushChannel() == null) {
-            FirebaseInstanceId.getInstance()
-                    .getInstanceId()
-                    .addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
+            FirebaseInstallations.getInstance().getToken(true)
+                    .addOnCompleteListener(new OnCompleteListener<InstallationTokenResult>() {
                         @Override
-                        public void onComplete(@NonNull Task<InstanceIdResult> task) {
+                        public void onComplete(@NonNull Task<InstallationTokenResult> task) {
                             if (!task.isSuccessful()) {
                                 Log.e("ANH", "unable to fetch FirebaseInstanceId");
                                 return;
                             }
+
                             mHub.setInstancePushChannel(task.getResult().getToken());
                         }
                     });

--- a/notification-hubs-sdk/src/fcm/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
+++ b/notification-hubs-sdk/src/fcm/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
@@ -51,15 +51,14 @@ public final class FirebaseReceiver extends FirebaseMessagingService {
 
         FirebaseInstallations.getInstance().getToken(true)
             .addOnCompleteListener(new OnCompleteListener<InstallationTokenResult>() {
-                    @Override
-                    public void onComplete(@NonNull Task<InstallationTokenResult> task) {
-                if (!task.isSuccessful()) {
-                    Log.e("ANH", "unable to fetch FirebaseInstanceId");
-                    return;
-                }
+                public void onComplete(@NonNull Task<InstallationTokenResult> task) {
+                    if (!task.isSuccessful()) {
+                        Log.e("ANH", "unable to fetch FirebaseInstanceId");
+                        return;
+                    }
 
-                mHub.setInstancePushChannel(task.getResult().getToken());
-                }
+                    mHub.setInstancePushChannel(task.getResult().getToken());
+                    }
                 });
     }
 

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -259,11 +259,9 @@ public final class NotificationHub {
 
     void setInstancePushChannel(String token) {
         if (token.equals(mPushChannelVisitor.getPushChannel())) {
-            Log.i("ANH", "requested push channel matches previous record, no operation necessary");
             return;
         }
         mPushChannelVisitor.setPushChannel(token);
-        Log.i("ANH", "updated local record of push channel");
         beginInstanceInstallationUpdate();
     }
 

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -259,9 +259,11 @@ public final class NotificationHub {
 
     void setInstancePushChannel(String token) {
         if (token.equals(mPushChannelVisitor.getPushChannel())) {
+            Log.i("ANH", "requested push channel matches previous record, no operation necessary");
             return;
         }
         mPushChannelVisitor.setPushChannel(token);
+        Log.i("ANH", "updated local record of push channel");
         beginInstanceInstallationUpdate();
     }
 


### PR DESCRIPTION
There have been several reports of customers migrating from App Center Push being unable to receive notifications if they were also using App Center Distribute. One example is Azure/azure-notificationhubs-xamarin#21.

Initial investigation showed that any call to update the Installation record was being rejected because the requests didn't have a device token. After validation that Firebase was initializing, and that there weren't multiple instances of FirebaseMessagingReceiver being created and fighting for registrations, attention was turned to the way we fetch the Firebase token. There seems to be a timing bug of sorts. For the sake of expediency, we are testing a defensive fix, where we are more aggressive about fetching device tokens at each time the application is started.

The fix in this PR is still under going testing. Further mitigatory fixes will be posted here.