### PR TITLE
Fetch FirebaseMessaging Token during NotificationHub.start call

### DIFF
--- a/notification-hubs-sdk/build.gradle
+++ b/notification-hubs-sdk/build.gradle
@@ -62,8 +62,10 @@ configurations {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.volley:volley:1.1.1'
-    fcmApi 'com.google.firebase:firebase-messaging:21.0.1'
-    generalApi 'com.google.firebase:firebase-messaging:21.0.1'
+
+    def firebaseMessagingVersion = '21.0.1'
+    fcmApi "com.google.firebase:firebase-messaging:${firebaseMessagingVersion}"
+    generalApi "com.google.firebase:firebase-messaging:${firebaseMessagingVersion}"
 
     javadocDeps 'com.android.support:support-annotations:28.0.0'
 

--- a/notification-hubs-sdk/src/fcm/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
+++ b/notification-hubs-sdk/src/fcm/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
@@ -1,14 +1,7 @@
 package com.microsoft.windowsazure.messaging.notificationhubs;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 
-import com.google.android.gms.tasks.OnCompleteListener;
-import com.google.android.gms.tasks.Task;
-import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.InstanceIdResult;
-import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 

--- a/notification-hubs-sdk/src/fcm/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
+++ b/notification-hubs-sdk/src/fcm/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
@@ -8,6 +8,7 @@ import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.iid.InstanceIdResult;
+import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
@@ -49,18 +50,16 @@ public final class FirebaseReceiver extends FirebaseMessagingService {
         mHub.registerApplication(this.getApplication());
 
         if (mHub.getInstancePushChannel() == null) {
-            FirebaseInstanceId.getInstance()
-                    .getInstanceId()
-                    .addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
-                        @Override
-                        public void onComplete(@NonNull Task<InstanceIdResult> task) {
-                            if (!task.isSuccessful()) {
-                                Log.e("ANH", "unable to fetch FirebaseInstanceId");
-                                return;
-                            }
-                            mHub.setInstancePushChannel(task.getResult().getToken());
-                        }
-                    });
+            FirebaseMessaging.getInstance().getToken().addOnCompleteListener(new OnCompleteListener<String>() {
+                @Override
+                public void onComplete(@NonNull Task<String> task) {
+                    if (!task.isSuccessful()) {
+                        Log.e("ANH", "unable to fetch FirebaseInstanceId");
+                        return;
+                    }
+                    mHub.setInstancePushChannel(task.getResult());
+                }
+            });
         }
     }
 

--- a/notification-hubs-sdk/src/fcm/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
+++ b/notification-hubs-sdk/src/fcm/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
@@ -48,19 +48,6 @@ public final class FirebaseReceiver extends FirebaseMessagingService {
         super.onCreate();
 
         mHub.registerApplication(this.getApplication());
-
-        if (mHub.getInstancePushChannel() == null) {
-            FirebaseMessaging.getInstance().getToken().addOnCompleteListener(new OnCompleteListener<String>() {
-                @Override
-                public void onComplete(@NonNull Task<String> task) {
-                    if (!task.isSuccessful()) {
-                        Log.e("ANH", "unable to fetch FirebaseInstanceId");
-                        return;
-                    }
-                    mHub.setInstancePushChannel(task.getResult());
-                }
-            });
-        }
     }
 
     /**

--- a/notification-hubs-sdk/src/fcm/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHubExtension.java
+++ b/notification-hubs-sdk/src/fcm/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHubExtension.java
@@ -1,0 +1,44 @@
+package com.microsoft.windowsazure.messaging.notificationhubs;
+
+import android.app.Application;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.messaging.FirebaseMessaging;
+
+/**
+ * Allows platform-specific functionality to be made available to the NotificationHub global single
+ * instance.
+ */
+class NotificationHubExtension {
+    /**
+     * Queries Firebase for the most recent token asynchronously.
+     *
+     * @param hub The instance of {@link NotificationHub} that should be made aware of the token.
+     */
+    public static void fetchPushChannel(final NotificationHub hub) {
+        /*
+         * Keeping this out of the NotificationHub class allows us to keep platform-specific knowledge
+         * from entering the shared-portion of the code-base.
+         *
+         * Keeping this out of the FirebaseReceiver class allows us to not rely on Service start-time
+         * behavior, which caused an issue for people adopting our platform:
+         * https://github.com/Azure/azure-notificationhubs-xamarin/issues/21
+         */
+        FirebaseMessaging.getInstance().getToken().addOnCompleteListener(new OnCompleteListener<String>() {
+            @Override
+            public void onComplete(@NonNull Task<String> task) {
+                if (!task.isSuccessful()) {
+                    Log.e("ANH", "unable to fetch FirebaseInstanceId");
+                    return;
+                }
+                hub.setInstancePushChannel(task.getResult());
+            }
+        });
+    }
+}

--- a/notification-hubs-sdk/src/general/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
+++ b/notification-hubs-sdk/src/general/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
@@ -47,21 +47,6 @@ public final class FirebaseReceiver extends FirebaseMessagingService {
         super.onCreate();
 
         mHub.registerApplication(this.getApplication());
-
-        if (mHub.getInstancePushChannel() == null) {
-            FirebaseInstanceId.getInstance()
-                    .getInstanceId()
-                    .addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
-                        @Override
-                        public void onComplete(@NonNull Task<InstanceIdResult> task) {
-                            if (!task.isSuccessful()) {
-                                Log.e("ANH", "unable to fetch FirebaseInstanceId");
-                                return;
-                            }
-                            mHub.setInstancePushChannel(task.getResult().getToken());
-                        }
-                    });
-        }
     }
 
     /**

--- a/notification-hubs-sdk/src/general/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
+++ b/notification-hubs-sdk/src/general/java/com/microsoft/windowsazure/messaging/notificationhubs/FirebaseReceiver.java
@@ -1,13 +1,7 @@
 package com.microsoft.windowsazure.messaging.notificationhubs;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 
-import com.google.android.gms.tasks.OnCompleteListener;
-import com.google.android.gms.tasks.Task;
-import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.InstanceIdResult;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 

--- a/notification-hubs-sdk/src/general/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHubExtension.java
+++ b/notification-hubs-sdk/src/general/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHubExtension.java
@@ -1,0 +1,44 @@
+package com.microsoft.windowsazure.messaging.notificationhubs;
+
+import android.app.Application;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.messaging.FirebaseMessaging;
+
+/**
+ * Allows platform-specific functionality to be made available to the NotificationHub global single
+ * instance.
+ */
+class NotificationHubExtension {
+    /**
+     * Queries Firebase for the most recent token asynchronously.
+     *
+     * @param hub The instance of {@link NotificationHub} that should be made aware of the token.
+     */
+    public static void fetchPushChannel(final NotificationHub hub) {
+        /*
+         * Keeping this out of the NotificationHub class allows us to keep platform-specific knowledge
+         * from entering the shared-portion of the code-base.
+         *
+         * Keeping this out of the FirebaseReceiver class allows us to not rely on Service start-time
+         * behavior, which caused an issue for people adopting our platform:
+         * https://github.com/Azure/azure-notificationhubs-xamarin/issues/21
+         */
+        FirebaseMessaging.getInstance().getToken().addOnCompleteListener(new OnCompleteListener<String>() {
+            @Override
+            public void onComplete(@NonNull Task<String> task) {
+                if (!task.isSuccessful()) {
+                    Log.e("ANH", "unable to fetch FirebaseInstanceId");
+                    return;
+                }
+                hub.setInstancePushChannel(task.getResult());
+            }
+        });
+    }
+}

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java
@@ -91,6 +91,8 @@ public final class NotificationHub {
 
         mUserIdVisitor = new UserIdVisitor(mApplication);
         useInstanceVisitor(mUserIdVisitor);
+
+        NotificationHubExtension.fetchPushChannel(this);
     }
 
     /**


### PR DESCRIPTION
This change moves the call that queries the FirebaseMessaging token to a component that can be called from the NotificationHub.start method as well as the FirebaseReceiver.

In doing this, we remove our dependency on having the FirebaseReceiver started before we can register the device with ANH.