### PR TITLE
Fix CI

### DIFF
--- a/.pipelines/pipeline.android.yaml
+++ b/.pipelines/pipeline.android.yaml
@@ -9,7 +9,7 @@ pr:
 - v1-preview
 
 pool:
-  name: Hosted Mac Internal
+  vmImage: macOS-latest
   demands: java
 
 steps:


### PR DESCRIPTION
Updates the hosted pool of machines that should be used for CI, including updating to the new name of the MacOS pipeline as detailed in [this blog post](https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/).