### PR TITLE
Updating Connection to throw NotificationHubExceptions with error responses

### DIFF
--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/Connection.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/Connection.java
@@ -256,13 +256,12 @@ class Connection {
 	}
 
 	/**
-	 * Reads the content from a HttpURLConnection to a string
+	 * Reads the content from a HttpURLConnection response to a string
 	 * @param conn	The HttpURLConnection to read
 	 * @return	The content string
-	 * @throws java.io.IOException
 	 */
-	private String getResponseContent(HttpURLConnection conn) throws IOException {
-		InputStream responseStream = null;
+	private String getResponseContent(HttpURLConnection conn) {
+		InputStream responseStream;
 		try {
 			responseStream = conn.getInputStream();
 		} catch (IOException ex) {

--- a/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/Connection.java
+++ b/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/Connection.java
@@ -262,9 +262,17 @@ class Connection {
 	 * @throws java.io.IOException
 	 */
 	private String getResponseContent(HttpURLConnection conn) throws IOException {
+		InputStream responseStream = null;
 		try {
-			InputStream instream = conn.getInputStream();
-			BufferedReader reader = new BufferedReader(new InputStreamReader(instream));
+			responseStream = conn.getInputStream();
+		} catch (IOException ex) {
+			responseStream = conn.getErrorStream();
+		}
+		if (responseStream == null) {
+			return null;
+		}
+		try {
+			BufferedReader reader = new BufferedReader(new InputStreamReader(responseStream));
 
 			StringBuilder sb = new StringBuilder();
 			String content = reader.readLine();


### PR DESCRIPTION
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

Updating `Connection.java` to pass response bodies from requests which errored out (response codes greater than and including 400) into the `NotificationHubException` that is thrown: `getInputStream()` only contains the response body for successful requests, which resulted in `NotificationHubException`s being thrown with no message when the result code was 4xx+

Tested via sample app with a malformed request to the backend (template registration with invalid template).
Before:
```
ex.toString():com.microsoft.windowsazure.messaging.NotificationHubException
ex.getStatusCode():400
ex.getMessage():null
e.printStackTrace():
com.microsoft.windowsazure.messaging.NotificationHubException
	at com.microsoft.windowsazure.messaging.Connection.executeRequest(Connection.java:257)
	at com.microsoft.windowsazure.messaging.Connection.executeRequest(Connection.java:171)
	at com.microsoft.windowsazure.messaging.Connection.executeRequest(Connection.java:131)
	at com.microsoft.windowsazure.messaging.NotificationHub.upsertRegistrationInternal(NotificationHub.java:465)
	at com.microsoft.windowsazure.messaging.NotificationHub.registerInternal(NotificationHub.java:429)
	at com.microsoft.windowsazure.messaging.NotificationHub.registerTemplate(NotificationHub.java:201)
	...
```


After:
```
ex.toString():com.microsoft.windowsazure.messaging.NotificationHubException: <Error xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><Code>400</Code><Detail>Failed to parse BodyTemplate: Invalid template payload. TrackingId:d04313e8-c1e2-4def-881e-b55020b78cdc,TimeStamp:4/11/2024 5:41:42 AM +00:00</Detail></Error>
ex.getStatusCode():400
ex.getMessage():<Error xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><Code>400</Code><Detail>Failed to parse BodyTemplate: Invalid template payload. TrackingId:d04313e8-c1e2-4def-881e-b55020b78cdc,TimeStamp:4/11/2024 5:41:42 AM +00:00</Detail></Error>
e.printStackTrace():
com.microsoft.windowsazure.messaging.NotificationHubException: <Error xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><Code>400</Code><Detail>Failed to parse BodyTemplate: Invalid template payload. TrackingId:d04313e8-c1e2-4def-881e-b55020b78cdc,TimeStamp:4/11/2024 5:41:42 AM +00:00</Detail></Error>
	at com.microsoft.windowsazure.messaging.Connection.executeRequest(Connection.java:257)
	at com.microsoft.windowsazure.messaging.Connection.executeRequest(Connection.java:171)
	at com.microsoft.windowsazure.messaging.Connection.executeRequest(Connection.java:131)
	at com.microsoft.windowsazure.messaging.NotificationHub.upsertRegistrationInternal(NotificationHub.java:465)
	at com.microsoft.windowsazure.messaging.NotificationHub.registerInternal(NotificationHub.java:429)
	at com.microsoft.windowsazure.messaging.NotificationHub.registerTemplate(NotificationHub.java:201)
	...
```
